### PR TITLE
feat: add insert_image MCP tool

### DIFF
--- a/.claude/skills/powerpoint-live/SKILL.md
+++ b/.claude/skills/powerpoint-live/SKILL.md
@@ -41,6 +41,7 @@ If the bridge has never been installed, see [setup guide](references/setup.md).
 | `get_slide` | Get detailed shapes (positions, text, colors) | `slideIndex`, `presentationId?` |
 | `get_slide_image` | Capture slide screenshot as PNG | `slideIndex`, `width?` (default 720), `presentationId?` |
 | `copy_slides` | Copy slides between two open presentations (data stays server-side) | `sourceSlideIndex`, `sourcePresentationId`, `destinationPresentationId`, `formatting?`, `targetSlideId?` |
+| `insert_image` | Insert image from file path, URL, or base64 data (data stays server-side for file/url) | `source`, `sourceType` (`file`/`url`/`base64`), `slideIndex?`, `left?`, `top?`, `width?`, `height?`, `presentationId?` |
 | `execute_officejs` | Run arbitrary Office.js code in the live presentation | `code`, `presentationId?` |
 
 `presentationId` is required only when multiple presentations are connected. Get it from `list_presentations`.
@@ -63,7 +64,7 @@ For `execute_officejs` code patterns, see [code-patterns.md](references/code-pat
 
 Cannot do via Office.js — do not attempt:
 
-- Insert images directly (workaround: `presentation.insertSlidesFromBase64()`)
+- Insert images with precise shape-level control (use `insert_image` tool — positions via Common API, not shape API)
 - Create or edit charts
 - Add animations or transitions
 - Apply gradients, shadows, or effects (solid fills only)

--- a/.claude/skills/powerpoint-live/references/code-patterns.md
+++ b/.claude/skills/powerpoint-live/references/code-patterns.md
@@ -116,6 +116,34 @@ var result = slide.getImageAsBase64({ width: 1280, height: 720 });
 await context.sync();
 ```
 
+## Inserting Images
+
+Use the `insert_image` MCP tool to insert images onto slides. Three source modes:
+
+```
+insert_image(
+  source: "/path/to/image.png",
+  sourceType: "file",         // reads from disk, data stays server-side
+  slideIndex: 0,              // optional: navigate to this slide first (0-based)
+  left: 100,                  // optional: position in points
+  top: 100,
+  width: 400,
+  height: 300,
+)
+
+insert_image(
+  source: "https://example.com/photo.jpg",
+  sourceType: "url",          // fetches from URL, data stays server-side
+)
+
+insert_image(
+  source: "iVBORw0KGgo...",
+  sourceType: "base64",       // raw base64 data
+)
+```
+
+For `file` and `url` modes, image data transfers server-side and never enters Claude's context. If position/size are omitted, Office.js uses defaults.
+
 ## Copying Slides Between Presentations
 
 Use the `copy_slides` MCP tool to copy slides between two open presentations. The Base64 data transfers server-side (Add-in A → Bridge Server → Add-in B) and never enters Claude's context.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ certs/
 coverage/
 *.tgz
 *.tsbuildinfo
+logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ For tool reference, code patterns, and usage — see the **powerpoint-live** ski
 
 - **WSS mandatory** - macOS WKWebView won't connect to `ws://localhost`, must use `wss://`
 - **Add-in cannot host servers** - sandboxed in WKWebView, can only make outbound connections
-- **No image API** - Office.js has no direct image insertion; workaround is Base64 slide import
+- **Limited image API** - Image insertion via Common API `setSelectedDataAsync` (`insert_image` tool); no shape-level `addPicture()` yet (BETA only)
 - **No charts** - Office.js cannot create charts
 - **No animations** - not exposed in stable APIs
 - **Solid fills only** - no gradients, effects, or shadows

--- a/README.md
+++ b/README.md
@@ -130,13 +130,14 @@ Add to your workspace `.vscode/mcp.json`:
 | `get_slide` | Returns detailed shape info for a slide (text, positions, sizes, fills) |
 | `get_slide_image` | Captures a visual screenshot of a slide as PNG (requires PowerPoint 16.96+) |
 | `copy_slides` | Copies slides between two open presentations (data stays server-side, never in Claude context) |
+| `insert_image` | Inserts an image from a file path, URL, or base64 data onto a slide |
 | `execute_officejs` | Runs arbitrary Office.js code inside the live presentation |
 
 When multiple presentations are open, pass `presentationId` (from `list_presentations`) to target a specific one.
 
 ## Limitations
 
-- **No images** — Office.js has no direct image insertion API; workaround is Base64 slide import
+- **Limited image control** — Images inserted via Common API (`insert_image` tool), not shape API; positioning works but no shape-level manipulation after insertion
 - **No charts** — Office.js cannot create charts programmatically
 - **No animations** — Not exposed in stable APIs
 - **Solid fills only** — No gradients, effects, or shadows

--- a/server/tools.test.ts
+++ b/server/tools.test.ts
@@ -6,6 +6,8 @@ import type { WebSocket } from 'ws'
 import { ConnectionPool } from './bridge.ts'
 import { registerTools } from './tools.ts'
 
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }))
+
 function mockWs(): WebSocket {
   return { send: vi.fn(), readyState: 1 } as unknown as WebSocket
 }
@@ -35,11 +37,11 @@ describe('MCP Tools', () => {
     pool = new ConnectionPool(100)
   })
 
-  it('lists all 6 tools', async () => {
+  it('lists all 7 tools', async () => {
     const { client } = await setupMcpClient(pool)
     const result = await client.listTools()
     const names = result.tools.map((t) => t.name).sort()
-    expect(names).toEqual(['copy_slides', 'execute_officejs', 'get_presentation', 'get_slide', 'get_slide_image', 'list_presentations'])
+    expect(names).toEqual(['copy_slides', 'execute_officejs', 'get_presentation', 'get_slide', 'get_slide_image', 'insert_image', 'list_presentations'])
   })
 
   describe('list_presentations', () => {
@@ -329,6 +331,195 @@ describe('MCP Tools', () => {
       expect(result.isError).toBe(true)
       const text = (result.content as Array<{ text: string }>)[0].text
       expect(text).toContain('missing.pptx')
+    })
+  })
+
+  describe('insert_image', () => {
+    it('passes base64 data directly into the code string', async () => {
+      const ws = mockWs()
+      pool.add('test.pptx', {
+        ws,
+        ready: true,
+        presentationId: 'test.pptx',
+        filePath: null,
+      })
+
+      const { client } = await setupMcpClient(pool)
+
+      const toolPromise = client.callTool({
+        name: 'insert_image',
+        arguments: {
+          source: 'iVBORw0KGgoAAAANSUhEUg==',
+          sourceType: 'base64',
+        },
+      })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      expect(sentJson.action).toBe('executeCode')
+      expect(sentJson.params.code).toContain('setSelectedDataAsync')
+      expect(sentJson.params.code).toContain('iVBORw0KGgoAAAANSUhEUg==')
+      expect(sentJson.params.code).toContain('CoercionType.Image')
+
+      pool.handleResponse(sentJson.id, 'response', { success: true })
+
+      const result = await toolPromise
+      const text = (result.content as Array<{ text: string }>)[0].text
+      const parsed = JSON.parse(text)
+      expect(parsed.success).toBe(true)
+    })
+
+    it('reads file and base64 encodes it', async () => {
+      const { readFileSync } = await import('node:fs')
+      vi.mocked(readFileSync).mockReturnValue(Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+
+      const ws = mockWs()
+      pool.add('test.pptx', {
+        ws,
+        ready: true,
+        presentationId: 'test.pptx',
+        filePath: null,
+      })
+
+      const { client } = await setupMcpClient(pool)
+
+      const toolPromise = client.callTool({
+        name: 'insert_image',
+        arguments: {
+          source: '/path/to/image.png',
+          sourceType: 'file',
+        },
+      })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      expect(readFileSync).toHaveBeenCalledWith('/path/to/image.png')
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      expect(sentJson.params.code).toContain('setSelectedDataAsync')
+      // The base64 of [0x89, 0x50, 0x4e, 0x47] is "iVBORw=="
+      expect(sentJson.params.code).toContain(Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64'))
+
+      pool.handleResponse(sentJson.id, 'response', { success: true })
+      await toolPromise
+    })
+
+    it('fetches URL and base64 encodes it', async () => {
+      const mockArrayBuffer = new Uint8Array([1, 2, 3]).buffer
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+      })
+
+      const ws = mockWs()
+      pool.add('test.pptx', {
+        ws,
+        ready: true,
+        presentationId: 'test.pptx',
+        filePath: null,
+      })
+
+      const { client } = await setupMcpClient(pool)
+
+      const toolPromise = client.callTool({
+        name: 'insert_image',
+        arguments: {
+          source: 'https://example.com/image.png',
+          sourceType: 'url',
+        },
+      })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      expect(globalThis.fetch).toHaveBeenCalledWith('https://example.com/image.png')
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      expect(sentJson.params.code).toContain('setSelectedDataAsync')
+      expect(sentJson.params.code).toContain(Buffer.from(new Uint8Array([1, 2, 3])).toString('base64'))
+
+      pool.handleResponse(sentJson.id, 'response', { success: true })
+      await toolPromise
+    })
+
+    it('wraps with goToByIdAsync when slideIndex is provided', async () => {
+      const ws = mockWs()
+      pool.add('test.pptx', {
+        ws,
+        ready: true,
+        presentationId: 'test.pptx',
+        filePath: null,
+      })
+
+      const { client } = await setupMcpClient(pool)
+
+      const toolPromise = client.callTool({
+        name: 'insert_image',
+        arguments: {
+          source: 'AAAA',
+          sourceType: 'base64',
+          slideIndex: 2,
+        },
+      })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      // slideIndex 2 (0-based) → goToByIdAsync(3, ...) (1-based)
+      expect(sentJson.params.code).toContain('goToByIdAsync(3,')
+      expect(sentJson.params.code).toContain('GoToType.Index')
+
+      pool.handleResponse(sentJson.id, 'response', { success: true })
+      await toolPromise
+    })
+
+    it('includes positioning options when provided', async () => {
+      const ws = mockWs()
+      pool.add('test.pptx', {
+        ws,
+        ready: true,
+        presentationId: 'test.pptx',
+        filePath: null,
+      })
+
+      const { client } = await setupMcpClient(pool)
+
+      const toolPromise = client.callTool({
+        name: 'insert_image',
+        arguments: {
+          source: 'BBBB',
+          sourceType: 'base64',
+          left: 100,
+          top: 50,
+          width: 400,
+          height: 300,
+        },
+      })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      expect(sentJson.params.code).toContain('imageLeft: 100')
+      expect(sentJson.params.code).toContain('imageTop: 50')
+      expect(sentJson.params.code).toContain('imageWidth: 400')
+      expect(sentJson.params.code).toContain('imageHeight: 300')
+
+      pool.handleResponse(sentJson.id, 'response', { success: true })
+      await toolPromise
+    })
+
+    it('returns error when no connections', async () => {
+      const { client } = await setupMcpClient(pool)
+      const result = await client.callTool({
+        name: 'insert_image',
+        arguments: {
+          source: 'AAAA',
+          sourceType: 'base64',
+        },
+      })
+      expect(result.isError).toBe(true)
+      const text = (result.content as Array<{ text: string }>)[0].text
+      expect(text).toContain('No presentations connected')
     })
   })
 

--- a/server/tools.ts
+++ b/server/tools.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { ConnectionPool } from './bridge.ts'
@@ -329,6 +330,94 @@ export function registerTools(
             null,
             2,
           ) + (warning ?? '')
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
+      }
+    },
+  )
+
+  // --- Tool: insert_image ---
+  server.tool(
+    'insert_image',
+    'Inserts an image onto a slide using Office.js setSelectedDataAsync with CoercionType.Image. Accepts a file path, URL, or raw base64 data. Optionally navigate to a specific slide first and control position/size in points.',
+    {
+      source: z.string().describe('File path, URL, or base64 image data depending on sourceType'),
+      sourceType: z
+        .enum(['file', 'url', 'base64'])
+        .describe('How to interpret source: "file" reads from disk, "url" fetches from network, "base64" uses data directly'),
+      slideIndex: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Zero-based slide index to navigate to before inserting. If omitted, inserts on the currently active slide.'),
+      left: z.number().optional().describe('Horizontal position in points (1 point = 1/72 inch)'),
+      top: z.number().optional().describe('Vertical position in points'),
+      width: z.number().optional().describe('Image width in points'),
+      height: z.number().optional().describe('Image height in points'),
+      presentationId: z
+        .string()
+        .optional()
+        .describe('Target presentation ID from list_presentations. Optional when only one presentation is connected.'),
+    },
+    async ({ source, sourceType, slideIndex, left, top, width, height, presentationId }) => {
+      try {
+        // Step 1: Resolve image to base64
+        let base64Data: string
+        if (sourceType === 'file') {
+          base64Data = readFileSync(source).toString('base64')
+        } else if (sourceType === 'url') {
+          const resp = await fetch(source)
+          if (!resp.ok) {
+            throw new Error(`Failed to fetch image from URL: ${resp.status} ${resp.statusText}`)
+          }
+          const buf = await resp.arrayBuffer()
+          base64Data = Buffer.from(buf).toString('base64')
+        } else {
+          base64Data = source
+        }
+
+        // Step 2: Build options object string with only provided params
+        const optionsParts: string[] = ['coercionType: Office.CoercionType.Image']
+        if (left !== undefined) optionsParts.push(`imageLeft: ${left}`)
+        if (top !== undefined) optionsParts.push(`imageTop: ${top}`)
+        if (width !== undefined) optionsParts.push(`imageWidth: ${width}`)
+        if (height !== undefined) optionsParts.push(`imageHeight: ${height}`)
+        const optionsStr = `{ ${optionsParts.join(', ')} }`
+
+        // Step 3: Build the setSelectedDataAsync call
+        const insertCall = `Office.context.document.setSelectedDataAsync("${base64Data}", ${optionsStr}, function(result) {
+        if (result.status === Office.AsyncResultStatus.Succeeded) {
+          resolve({ success: true });
+        } else {
+          reject(new Error(result.error.message));
+        }
+      });`
+
+        // Step 4: Wrap with goToByIdAsync if slideIndex is provided
+        let code: string
+        if (slideIndex !== undefined) {
+          code = `return new Promise(function(resolve, reject) {
+      Office.context.document.goToByIdAsync(${slideIndex + 1}, Office.GoToType.Index, function(navResult) {
+        if (navResult.status !== Office.AsyncResultStatus.Succeeded) {
+          reject(new Error("Navigation failed: " + navResult.error.message));
+          return;
+        }
+        ${insertCall}
+      });
+    });`
+        } else {
+          code = `return new Promise(function(resolve, reject) {
+      ${insertCall}
+    });`
+        }
+
+        const target = pool.resolveTarget(presentationId)
+        const result = await pool.sendCommand('executeCode', { code }, target.ws)
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount())
+        const text = JSON.stringify(result ?? { success: true }, null, 2) + (warning ?? '')
         return { content: [{ type: 'text' as const, text }] }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary

- Adds `insert_image` MCP tool that inserts images onto live slides via Office.js Common API (`setSelectedDataAsync` with `CoercionType.Image`)
- Three source modes: `file` (reads from disk), `url` (fetches from network), `base64` (direct data)
- File and URL modes keep image data server-side — never enters Claude's context
- Optional `slideIndex` navigation via `goToByIdAsync` and `left`/`top`/`width`/`height` positioning in points
- 6 new tests covering all modes, navigation, positioning, and error cases

Closes #10

## Test plan

- [x] All 35 tests pass (`npx vitest run`)
- [x] Live-tested all 3 modes (file, url, base64) against real PowerPoint presentation
- [x] Verified positioning with `get_slide_image` screenshots
- [x] Tested slide navigation with `slideIndex` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)