### PR TITLE
refactor: move setup instructions to references/setup.md

### DIFF
--- a/.claude/skills/powerpoint-live/SKILL.md
+++ b/.claude/skills/powerpoint-live/SKILL.md
@@ -11,26 +11,9 @@ Edit live, open PowerPoint presentations through an MCP bridge. Changes appear i
 Claude Code  ──MCP HTTP (localhost:3001)──>  Bridge Server  ──WSS──>  PowerPoint Add-in  ──>  Live Presentation
 ```
 
-## Enabling in a Project
+## Setup
 
-When asked to enable, configure, or set up PowerPoint MCP in a project:
-
-1. Add to the project's `.mcp.json` (create if missing):
-   ```json
-   {
-     "mcpServers": {
-       "powerpoint-bridge": {
-         "type": "http",
-         "url": "http://localhost:3001/mcp"
-       }
-     }
-   }
-   ```
-2. Verify server is reachable: `curl -s http://localhost:3001/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'`
-3. If server unreachable, direct user: "Start the bridge server: `cd ~/powerpoint-bridge && npm start`"
-4. Test: call `list_presentations` to confirm connectivity
-
-If the bridge has never been installed, see [setup guide](references/setup.md).
+When asked to enable, configure, or set up PowerPoint MCP — follow the [setup guide](references/setup.md). It covers both global installation (run once) and per-project configuration (idempotent).
 
 ## MCP Tools
 

--- a/.claude/skills/powerpoint-live/references/setup.md
+++ b/.claude/skills/powerpoint-live/references/setup.md
@@ -57,3 +57,45 @@ The server runs on:
 **MCP not connecting**
 - Verify: `curl http://localhost:3001/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'`
 - Should return JSON with `serverInfo`
+
+## Per-Project Setup
+
+Run these steps when asked to enable PowerPoint MCP in a project. Each step is idempotent — check before acting, skip what's already done.
+
+### 1. Check if already configured
+
+Look for `powerpoint-bridge` in the project's `.mcp.json`. If it exists and points to `http://localhost:3001/mcp`, skip to step 4 (verify).
+
+### 2. Add MCP config
+
+Create or merge into the project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "powerpoint-bridge": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
+    }
+  }
+}
+```
+
+If `.mcp.json` already exists with other servers, merge — do not overwrite.
+
+### 3. Check server is running
+
+```bash
+curl -s http://localhost:3001/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+```
+
+- If responds with JSON containing `serverInfo` — server is running, continue.
+- If fails — tell user: "Start the bridge server: `cd ~/powerpoint-bridge && npm start`"
+
+### 4. Verify connectivity
+
+Call `list_presentations`. If it returns results or "No presentations connected", setup is complete. Report status to user.
+
+### Not installed at all?
+
+If the bridge repo doesn't exist at `~/powerpoint-bridge`, direct the user to the [global installation](#install) section above.


### PR DESCRIPTION
## Summary

- Moves inline setup instructions (`.mcp.json` config) out of SKILL.md into `references/setup.md`
- SKILL.md now has a one-line pointer to the setup guide
- Adds idempotent Per-Project Setup section with check-before-act steps
- Agent figures out what's already done and skips it on repeated runs

## Test plan

- [x] SKILL.md stays under 70 lines (lean)
- [x] setup.md covers both global install and per-project config
- [x] Per-project steps are idempotent (check `.mcp.json` first, skip if configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)