### PR TITLE
feat: make package npx-installable for universal MCP client distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ certs/
 .idea/
 *.swp
 coverage/
+dist/
 *.tgz
 *.tsbuildinfo
 logs/

--- a/README.md
+++ b/README.md
@@ -7,6 +7,79 @@ An MCP server that lets AI assistants manipulate **live, open** PowerPoint prese
 
 Unlike file-based tools (python-pptx), PowerPoint Bridge works with presentations that are already open — changes appear instantly, and you keep full access to PowerPoint's UI, animations, and formatting.
 
+## Installation
+
+Run as an MCP server via npx (no install needed):
+
+```bash
+npx powerpoint-bridge --stdio --bridge
+```
+
+Then configure your MCP client:
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "powerpoint-bridge": {
+      "command": "npx",
+      "args": ["-y", "powerpoint-bridge", "--stdio", "--bridge"]
+    }
+  }
+}
+```
+
+**Claude Code** (`.mcp.json` in project root):
+```json
+{
+  "mcpServers": {
+    "powerpoint-bridge": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "powerpoint-bridge", "--stdio", "--bridge"]
+    }
+  }
+}
+```
+
+**Cursor** (`.cursor/mcp.json`):
+```json
+{
+  "mcpServers": {
+    "powerpoint-bridge": {
+      "command": "npx",
+      "args": ["-y", "powerpoint-bridge", "--stdio", "--bridge"]
+    }
+  }
+}
+```
+
+**VS Code / GitHub Copilot** (`.vscode/mcp.json`):
+```json
+{
+  "servers": {
+    "powerpoint-bridge": {
+      "command": "npx",
+      "args": ["-y", "powerpoint-bridge", "--stdio", "--bridge"]
+    }
+  }
+}
+```
+
+**Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+```json
+{
+  "mcpServers": {
+    "powerpoint-bridge": {
+      "command": "npx",
+      "args": ["-y", "powerpoint-bridge", "--stdio", "--bridge"]
+    }
+  }
+}
+```
+
+> **Note:** The PowerPoint add-in must still be sideloaded separately. See [Setup](#setup) for details.
+
 ## Motivation
 
 This project was inspired by the [Claude in PowerPoint](https://support.anthropic.com/en/articles/11360939-using-claude-in-powerpoint) add-in. The first time I tried it, I was amazed — it edits live, open decks via Office.js, and the results are far better than file-based pptx tools. But it only works inside the add-in, which means no access to CLAUDE.md, skills, or any other Claude Code features. PowerPoint Bridge brings those same Office.js capabilities to Claude Code (and any MCP client) so you get live editing with the full power of your coding environment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,18 +13,22 @@
         "ws": "^8.19.0",
         "zod": "^4.3.6"
       },
+      "bin": {
+        "powerpoint-bridge": "dist/index.js"
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.3.14",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.0.18",
+        "esbuild": "^0.27.3",
         "husky": "^9.1.7",
         "lint-staged": "^16.3.2",
         "typescript": "^5.9.0",
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=24.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
   "version": "0.1.0",
   "description": "MCP server that lets AI assistants manipulate live PowerPoint presentations via Office.js",
   "type": "module",
-  "private": true,
+  "main": "dist/index.js",
   "bin": {
-    "powerpoint-bridge": "./server/index.ts"
+    "powerpoint-bridge": "./dist/index.js"
   },
+  "files": [
+    "dist/",
+    "addin/",
+    "README.md",
+    "LICENSE"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -18,6 +24,7 @@
   },
   "keywords": [
     "mcp",
+    "mcp-server",
     "powerpoint",
     "office-js",
     "live-editing",
@@ -25,9 +32,11 @@
     "claude"
   ],
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
+    "build": "esbuild server/index.ts --bundle --platform=node --format=esm --outfile=dist/index.js --banner:js='#!/usr/bin/env node' --external:@modelcontextprotocol/sdk --external:ws --external:zod",
+    "prepublishOnly": "npm run build",
     "setup": "bash scripts/setup.sh",
     "start": "node server/index.ts",
     "typecheck": "tsc --noEmit",
@@ -53,6 +62,7 @@
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.0.18",
+    "esbuild": "^0.27.3",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.2",
     "typescript": "^5.9.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { randomUUID } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
 import type { IncomingMessage, ServerResponse } from 'node:http'


### PR DESCRIPTION
## Summary
Closes #31

- Add esbuild build step that bundles `server/*.ts` into a single `dist/index.js` (42KB)
- Any MCP client can now use the server via `npx powerpoint-bridge --stdio --bridge`
- README includes config snippets for Claude Desktop, Claude Code, Cursor, VS Code/Copilot, and Windsurf
- Node 18+ compatible (no longer requires Node 24 for published package)

## Changes
- Add `esbuild` dev dependency and `build`/`prepublishOnly` scripts
- Point `bin` and `main` to `dist/index.js` with shebang banner
- Add `files` field to scope npm package (dist/, addin/)
- Remove `private: true` for npm publishing
- Add `dist/` to `.gitignore`
- Remove shebang from source `server/index.ts` (esbuild banner handles it)

## Test plan
- [x] `npm run build` produces `dist/index.js` with shebang
- [x] `echo '{"jsonrpc":"2.0","id":1,...}' | node dist/index.js --stdio` returns valid MCP response
- [x] `tools/list` returns all 9 tools with correct schemas
- [x] `npx powerpoint-bridge --stdio` works via bin entry
- [x] `npm pack --dry-run` includes only dist/, addin/, README, LICENSE (12 files, 18KB)
- [x] All 56 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)