### PR TITLE
feat: .mcpb release workflow + version sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "powerpoint-bridge",
   "description": "MCP bridge for live-editing open PowerPoint presentations on macOS via Office.js",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": {
     "name": "Krzysztof Zarzycki",
     "email": "k.zarzycki@gmail.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.3.0). Must already exist.'
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+
+  release:
+    needs: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build server bundle
+        run: npm run build
+
+      - name: Prepare mcpb staging directory
+        run: |
+          STAGE_DIR="dist/mcpb-stage"
+          rm -rf "$STAGE_DIR"
+          mkdir -p "$STAGE_DIR/server" "$STAGE_DIR/addin/assets"
+
+          cp dist/index.cjs "$STAGE_DIR/server/index.cjs"
+
+          cp addin/index.html addin/app.js addin/style.css "$STAGE_DIR/addin/"
+          cp addin/manifest.xml addin/manifest-https.xml "$STAGE_DIR/addin/"
+          cp addin/assets/*.png "$STAGE_DIR/addin/assets/"
+
+          cp manifest.json "$STAGE_DIR/"
+          cp addin/assets/icon-80.png "$STAGE_DIR/icon.png"
+
+      - name: Pack .mcpb extension
+        run: |
+          cd dist/mcpb-stage
+          npx @anthropic-ai/mcpb pack
+
+      - name: Prepare release artifact
+        id: artifact
+        run: |
+          VERSION=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)")
+          MCPB_FILE="powerpoint-bridge-v${VERSION}.mcpb"
+
+          PACKED=$(ls dist/mcpb-stage/*.mcpb 2>/dev/null | head -1)
+          if [ -z "$PACKED" ]; then
+            echo "Error: No .mcpb file found after packing"
+            exit 1
+          fi
+          mv "$PACKED" "$MCPB_FILE"
+
+          echo "mcpb_file=$MCPB_FILE" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            "${{ steps.artifact.outputs.mcpb_file }}" \
+            --title "PowerPoint Bridge ${{ steps.tag.outputs.tag }}" \
+            --generate-notes \
+            --latest

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "powerpoint-bridge",
   "display_name": "PowerPoint Bridge",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Manipulate live, open PowerPoint presentations via Office.js — add shapes, text, images, and more to open presentations in real time.",
   "long_description": "PowerPoint Bridge lets Claude control live, open PowerPoint presentations on macOS through Office.js APIs. Unlike file-based solutions, this extension manipulates the presentation in real time.\n\n**Capabilities:**\n- Add and modify shapes, text boxes, tables, and images\n- Read slide structure and content\n- Take visual screenshots of slides\n- Copy slides between presentations\n- Execute arbitrary Office.js code\n\n**How it works:**\nThe extension runs a local bridge server that connects to a PowerPoint add-in via WebSocket. On first launch, the add-in is automatically installed into PowerPoint.\n\n**Requirements:** Microsoft PowerPoint for Mac (16.96+), macOS.",
   "author": {
@@ -18,26 +18,59 @@
   "icon": "icon.png",
   "server": {
     "type": "node",
-    "entry_point": "server/index.js",
+    "entry_point": "server/index.cjs",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/server/index.js", "--stdio", "--bridge"],
+      "args": [
+        "${__dirname}/server/index.cjs",
+        "--stdio",
+        "--bridge"
+      ],
       "env": {}
     }
   },
   "tools": [
-    { "name": "list_presentations", "description": "List all connected PowerPoint presentations" },
-    { "name": "get_presentation", "description": "Get the structure of a presentation (slides and shapes)" },
-    { "name": "get_slide", "description": "Get detailed information about shapes on a specific slide" },
-    { "name": "get_slide_image", "description": "Capture a slide as a PNG screenshot" },
-    { "name": "get_deck_overview", "description": "Visual overview of all slides with thumbnails" },
-    { "name": "get_local_copy", "description": "Export presentation to a local file path" },
-    { "name": "copy_slides", "description": "Copy slides between open presentations" },
-    { "name": "insert_image", "description": "Insert an image onto a slide" },
-    { "name": "execute_officejs", "description": "Execute arbitrary Office.js code in the live presentation" }
+    {
+      "name": "list_presentations",
+      "description": "List all connected PowerPoint presentations"
+    },
+    {
+      "name": "get_presentation",
+      "description": "Get the structure of a presentation (slides and shapes)"
+    },
+    {
+      "name": "get_slide",
+      "description": "Get detailed information about shapes on a specific slide"
+    },
+    {
+      "name": "get_slide_image",
+      "description": "Capture a slide as a PNG screenshot"
+    },
+    {
+      "name": "get_deck_overview",
+      "description": "Visual overview of all slides with thumbnails"
+    },
+    {
+      "name": "get_local_copy",
+      "description": "Export presentation to a local file path"
+    },
+    {
+      "name": "copy_slides",
+      "description": "Copy slides between open presentations"
+    },
+    {
+      "name": "insert_image",
+      "description": "Insert an image onto a slide"
+    },
+    {
+      "name": "execute_officejs",
+      "description": "Execute arbitrary Office.js code in the live presentation"
+    }
   ],
   "compatibility": {
-    "platforms": ["darwin"],
+    "platforms": [
+      "darwin"
+    ],
     "runtimes": {
       "node": ">=16.0.0"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powerpoint-bridge",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powerpoint-bridge",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerpoint-bridge",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "MCP server that lets AI assistants manipulate live PowerPoint presentations via Office.js",
   "type": "module",
   "main": "dist/index.js",
@@ -52,6 +52,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "check": "biome check . && tsc --noEmit && vitest run",
+    "version": "bash scripts/sync-version.sh",
+    "release": "bash scripts/release.sh",
     "build:mcpb": "bash scripts/build-mcpb.sh",
     "sideload": "mkdir -p ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef && cp addin/manifest.xml ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef/manifest.xml",
     "sideload:https": "mkdir -p ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef && cp addin/manifest-https.xml ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef/manifest.xml",

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -2,56 +2,51 @@
 set -e
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-DIST_DIR="$REPO_DIR/dist"
+STAGE_DIR="$REPO_DIR/dist/mcpb-stage"
 
 echo "=== Building PowerPoint Bridge .mcpb ==="
 
-# 1. Clean
-rm -rf "$DIST_DIR"
-mkdir -p "$DIST_DIR/server" "$DIST_DIR/addin/assets"
+# 1. Build CJS bundle
+echo "[build] Building self-contained CJS bundle..."
+cd "$REPO_DIR"
+npm run build
 
-# 2. Bundle server with esbuild (all TS + deps → single JS file)
-echo "[build] Bundling server..."
-npx esbuild "$REPO_DIR/server/index.ts" \
-  --bundle \
-  --platform=node \
-  --target=node16 \
-  --format=esm \
-  --outfile="$DIST_DIR/server/index.js" \
-  --external:ws
+# 2. Clean staging area
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR/server" "$STAGE_DIR/addin/assets"
 
-echo "[build] Server bundle: $(wc -c < "$DIST_DIR/server/index.js" | tr -d ' ') bytes"
+# 3. Copy self-contained CJS bundle (no node_modules needed)
+echo "[build] Copying server bundle..."
+cp "$REPO_DIR/dist/index.cjs" "$STAGE_DIR/server/index.cjs"
 
-# 3. Copy ws dependency (CJS package, must be external for ESM bundle)
-echo "[build] Copying ws dependency..."
-mkdir -p "$DIST_DIR/node_modules"
-cp -r "$REPO_DIR/node_modules/ws" "$DIST_DIR/node_modules/ws"
-
-# 5. Copy add-in static files
+# 4. Copy add-in static files
 echo "[build] Copying add-in files..."
-cp "$REPO_DIR/addin/index.html" "$REPO_DIR/addin/app.js" "$REPO_DIR/addin/style.css" "$DIST_DIR/addin/"
-cp "$REPO_DIR/addin/manifest.xml" "$REPO_DIR/addin/manifest-https.xml" "$DIST_DIR/addin/"
-cp "$REPO_DIR/addin/assets/"*.png "$DIST_DIR/addin/assets/"
+cp "$REPO_DIR/addin/index.html" "$REPO_DIR/addin/app.js" "$REPO_DIR/addin/style.css" "$STAGE_DIR/addin/"
+cp "$REPO_DIR/addin/manifest.xml" "$REPO_DIR/addin/manifest-https.xml" "$STAGE_DIR/addin/"
+cp "$REPO_DIR/addin/assets/"*.png "$STAGE_DIR/addin/assets/"
 
-# 6. Copy manifest and icon
-cp "$REPO_DIR/manifest.json" "$DIST_DIR/"
-cp "$REPO_DIR/addin/assets/icon-80.png" "$DIST_DIR/icon.png"
+# 5. Copy manifest and icon
+cp "$REPO_DIR/manifest.json" "$STAGE_DIR/"
+cp "$REPO_DIR/addin/assets/icon-80.png" "$STAGE_DIR/icon.png"
 
-# 7. Pack as .mcpb
+# 6. Pack as .mcpb
 VERSION=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$REPO_DIR/package.json','utf8')).version)")
 MCPB_FILE="$REPO_DIR/powerpoint-bridge-v${VERSION}.mcpb"
 
 echo "[pack] Creating $MCPB_FILE..."
-cd "$DIST_DIR"
+cd "$STAGE_DIR"
 npx @anthropic-ai/mcpb pack
 
-# Move the output .mcpb to repo root if mcpb outputs it in dist
-PACKED=$(ls "$DIST_DIR"/*.mcpb 2>/dev/null | head -1)
+# Move the output .mcpb to repo root
+PACKED=$(ls "$STAGE_DIR"/*.mcpb 2>/dev/null | head -1)
 if [ -n "$PACKED" ]; then
   mv "$PACKED" "$MCPB_FILE"
 fi
 
+# Clean up staging
+rm -rf "$STAGE_DIR"
+
 echo ""
 echo "=== Done ==="
 echo "Output: $MCPB_FILE"
-echo "To install: open the .mcpb file with Claude Desktop"
+echo "Install: Claude Desktop → Settings → Extensions → Advanced → Install Extension"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Cut a release: validate, bump version, push tag → GitHub Actions builds .mcpb.
+# Usage: npm run release -- patch|minor|major
+#    or: bash scripts/release.sh patch|minor|major
+set -e
+
+BUMP="${1:-patch}"
+
+if [ "$BUMP" != "patch" ] && [ "$BUMP" != "minor" ] && [ "$BUMP" != "major" ]; then
+  echo "Usage: npm run release -- <patch|minor|major>"
+  exit 1
+fi
+
+# Ensure clean working tree
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: Working tree is not clean. Commit or stash changes first."
+  exit 1
+fi
+
+# Ensure on main
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" != "main" ]; then
+  echo "Warning: You are on branch '$BRANCH', not 'main'. Continue? (y/N)"
+  read -r CONFIRM
+  if [ "$CONFIRM" != "y" ]; then
+    exit 1
+  fi
+fi
+
+# Run checks before bumping
+echo "[release] Running checks..."
+npm run check
+
+# Bump version (triggers "version" script which syncs manifest + plugin.json)
+echo "[release] Bumping $BUMP version..."
+npm version "$BUMP"
+
+# Push commit and tag
+echo "[release] Pushing to origin..."
+git push origin "$BRANCH" --follow-tags
+
+echo ""
+echo "=== Release pushed ==="
+echo "GitHub Actions will now build the .mcpb and create the GitHub Release."
+echo "Monitor at: https://github.com/kzarzycki/powerpoint-bridge/actions"

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Syncs version from package.json into manifest.json and .claude-plugin/plugin.json.
+# Called automatically by npm version lifecycle (the "version" script in package.json).
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION=$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('$REPO_DIR/package.json','utf8')).version)")
+
+echo "[sync-version] Syncing version $VERSION to manifest.json and plugin.json"
+
+# Update manifest.json
+node -e "
+const fs = require('fs');
+const path = '$REPO_DIR/manifest.json';
+const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+data.version = '$VERSION';
+fs.writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+"
+
+# Update .claude-plugin/plugin.json
+node -e "
+const fs = require('fs');
+const path = '$REPO_DIR/.claude-plugin/plugin.json';
+const data = JSON.parse(fs.readFileSync(path, 'utf8'));
+data.version = '$VERSION';
+fs.writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+"
+
+# Stage the updated files so they're included in npm version's auto-commit
+git add "$REPO_DIR/manifest.json" "$REPO_DIR/.claude-plugin/plugin.json"
+
+echo "[sync-version] Done: all version files set to $VERSION"


### PR DESCRIPTION
## Summary
- Add GitHub Actions release workflow (`.github/workflows/release.yml`) — triggered by `v*` tags, builds .mcpb and publishes as GitHub Release artifact
- Add `scripts/sync-version.sh` — keeps `manifest.json` and `plugin.json` in sync with `package.json` via `npm version` lifecycle hook
- Add `scripts/release.sh` — local convenience: `npm run release -- patch|minor|major`
- Unify versions at `0.3.0` (was: package.json 0.1.0, manifest.json 0.1.0, plugin.json 0.2.1)
- Security: SHA-pinned actions, per-job permissions, timeouts, concurrency control

## Release flow after merge
```
npm run release -- minor
```
→ runs checks → bumps version → syncs all files → pushes tag → GitHub Actions builds .mcpb → creates Release with artifact

Closes #35

## Test plan
- [ ] Verify `npm run build:mcpb` still works locally
- [ ] Test version sync: `npm version --no-git-tag-version patch` → check all 3 files updated
- [ ] After merge, push `v0.3.0` tag → verify GitHub Actions creates release with .mcpb
- [ ] Download .mcpb from release → install in Claude Desktop → verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)