### PR TITLE
chore: add categorized release notes and PR title enforcement

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+      - question
+  categories:
+    - title: "New Features"
+      labels:
+        - enhancement
+    - title: "Bug Fixes"
+      labels:
+        - bug
+    - title: "Internal"
+      labels:
+        - internal

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,46 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      contents: read
+    steps:
+      - name: Check conventional commit prefix
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          PATTERN="^(feat|fix|chore|refactor|ci|docs|build|test|perf)(\(.+\))?: .+"
+          if [[ ! "$TITLE" =~ $PATTERN ]]; then
+            echo "::error::PR title must follow Conventional Commits: type: description"
+            echo "  Accepted types: feat, fix, chore, refactor, ci, docs, build, test, perf"
+            echo "  Example: feat: add slide transition support"
+            echo "  Got: $TITLE"
+            exit 1
+          fi
+
+  auto-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Apply label from title prefix
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          PR=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+
+          if [[ "$TITLE" =~ ^feat ]]; then
+            gh pr edit "$PR" --repo "$REPO" --add-label "enhancement"
+          elif [[ "$TITLE" =~ ^fix ]]; then
+            gh pr edit "$PR" --repo "$REPO" --add-label "bug"
+          elif [[ "$TITLE" =~ ^(chore|refactor|ci|docs|build|test|perf) ]]; then
+            gh pr edit "$PR" --repo "$REPO" --add-label "internal"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,10 @@ For tool reference, code patterns, and usage — see the **powerpoint-live** ski
 - **Solid fills only** - no gradients, effects, or shadows
 - **Points for positioning** - 1 point = 1/72 inch
 
+## Conventions
+
+- PR titles and commits follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
+
 ## Key Technical Decisions
 
 1. **Single Node.js process** for HTTP(S) + WS(S) + MCP (simplicity over microservices)


### PR DESCRIPTION
## Summary
- `.github/release.yml`: categorize release notes into **New Features** / **Bug Fixes** / **Internal**
- `.github/workflows/pr-title.yml`: validate PR titles follow Conventional Commits + auto-apply labels (`enhancement`, `bug`, `internal`)
- `CLAUDE.md`: document the convention
- Created `internal` label for non-user-facing changes

## Test plan
- [ ] This PR itself should get auto-labeled `internal` by the new workflow
- [ ] Verify PR title validation passes (this PR uses `chore:` prefix)
- [ ] After merge, future releases will show categorized notes
- [ ] Set `pr-title / validate` as required status check on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)