### PR TITLE
fix: skip sideload on restart to avoid repeated macOS TCC prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/*.map
 *.tsbuildinfo
 *.mcpb
 logs/
+.sideloaded

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "version": "bash scripts/sync-version.sh",
     "release": "bash scripts/release.sh",
     "build:mcpb": "bash scripts/build-mcpb.sh",
-    "sideload": "mkdir -p ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef && cp addin/manifest.xml ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef/manifest.xml",
-    "sideload:https": "mkdir -p ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef && cp addin/manifest-https.xml ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef/manifest.xml",
+    "sideload": "mkdir -p ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef && cp addin/manifest.xml ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef/manifest.xml && node -p \"require('./package.json').version\" > .sideloaded",
+    "sideload:https": "mkdir -p ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef && cp addin/manifest-https.xml ~/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef/manifest.xml && node -p \"require('./package.json').version\" > .sideloaded",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,6 +10,7 @@ echo ""
 WEF_DIR="$HOME/Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef"
 mkdir -p "$WEF_DIR"
 cp "$REPO_DIR/addin/manifest.xml" "$WEF_DIR/"
+node -p "require('$REPO_DIR/package.json').version" > "$REPO_DIR/.sideloaded"
 echo "[add-in] Manifest sideloaded to PowerPoint (HTTP mode)"
 
 # 2. Install skill globally (skip if running as a Claude Code plugin)

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { createServer as createHttpServer } from 'node:http'
 import { createServer as createHttpsServer } from 'node:https'
@@ -102,6 +102,31 @@ const BRIDGE_PORT =
 // ---------------------------------------------------------------------------
 
 function autoSideloadManifest(tls: boolean): void {
+  // Sideloading copies the add-in manifest into PowerPoint's sandboxed container,
+  // which triggers a macOS TCC prompt ("node would like to access data from other
+  // apps"). We use a versioned marker file (.sideloaded) to skip sideloading when
+  // the version hasn't changed, so the prompt only appears on first install or
+  // after an update. Use `npm run sideload` to force re-install.
+  const markerFile = resolve(PROJECT_ROOT, '.sideloaded')
+  const pkgPath = resolve(PROJECT_ROOT, 'package.json')
+
+  let currentVersion = 'unknown'
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+    currentVersion = pkg.version
+  } catch {}
+
+  try {
+    const markerVersion = readFileSync(markerFile, 'utf8').trim()
+    if (markerVersion === currentVersion) {
+      console.error('[sideload] Add-in already installed (use `npm run sideload` to update)')
+      return
+    }
+    console.error(`[sideload] Version changed (${markerVersion} → ${currentVersion}), re-sideloading`)
+  } catch {
+    // marker doesn't exist — first install
+  }
+
   const wefDir = join(homedir(), 'Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef')
   const manifestName = tls ? 'manifest-https.xml' : 'manifest.xml'
   const src = resolve(ADDIN_STATIC_DIR, manifestName)
@@ -110,6 +135,7 @@ function autoSideloadManifest(tls: boolean): void {
     if (!existsSync(src)) return
     mkdirSync(wefDir, { recursive: true })
     copyFileSync(src, dest)
+    writeFileSync(markerFile, currentVersion)
     console.error('[sideload] Add-in manifest installed for PowerPoint')
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary
- Use a versioned marker file (`.sideloaded`) at project root instead of `~/.powerpoint-bridge/sideloaded`
- On startup, compare marker version with `package.json` version — only sideload if they differ (fresh install or update)
- `npm run sideload` / `sideload:https` and `scripts/setup.sh` also write the marker, keeping everything in sync

## Test plan
- [ ] Delete `.sideloaded` → `npm start` with `--bridge` → sideloads once, writes marker, TCC prompt fires
- [ ] `npm start --bridge` again → skips sideload, no TCC prompt
- [ ] `npm run sideload` → copies manifest AND writes marker
- [ ] Edit `.sideloaded` to `0.0.0` → `npm start --bridge` → re-sideloads (version mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)