### PR TITLE
chore: enforce build workflow and add development practices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,7 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm test
+      - name: Verify dist/index.cjs is up to date
+        run: |
+          npm run build
+          git diff --exit-code dist/index.cjs || (echo "dist/index.cjs is stale — run 'npm run build' and commit" && exit 1)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,10 @@
+# Fail if server/ files are staged but dist/index.cjs is not
+if git diff --cached --name-only | grep -q '^server/' && \
+   ! git diff --cached --name-only | grep -q '^dist/index.cjs$'; then
+  echo "Error: server/ files changed but dist/index.cjs not staged."
+  echo "Run: npm run build && git add dist/index.cjs"
+  exit 1
+fi
+
 npx lint-staged
 npm run typecheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,23 @@ For tool reference, code patterns, and usage — see the **powerpoint-live** ski
 
 - PR titles and commits follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
 
+## Development Workflow
+
+### Build
+- **After changing `server/` files**: Run `npm run build` and stage `dist/index.cjs` — it's committed and used by plugin/MCPB installs. The pre-commit hook enforces this.
+- **Quality gate**: Use `npm run check` (runs lint + typecheck + test in one command)
+
+### Branch & PR
+- Create a feature branch: `<type>/<short-description>` (e.g. `fix/tcc-sideload-prompt`, `feat/new-tool`)
+- PR title must follow Conventional Commits — CI enforces this and auto-labels (`feat`→enhancement, `fix`→bug, etc.)
+- Squash merge PRs to keep main history clean
+- Delete feature branch after merge
+
+### Code Quality
+- **TDD (red-green)**: Write failing tests first, then implement to make them pass
+- After implementation, use `/simplify` to review changed code
+- Run `npm run check` before pushing
+
 ## Key Technical Decisions
 
 1. **Single Node.js process** for HTTP(S) + WS(S) + MCP (simplicity over microservices)

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -35507,6 +35507,23 @@ if (bridgeActive && bridgeTls && (!(0, import_node_fs2.existsSync)(BRIDGE_CERT_P
 }
 var BRIDGE_PORT = Number(process.env.BRIDGE_PORT) || (bridgeTls ? BRIDGE_DEFAULT_HTTPS_PORT : BRIDGE_DEFAULT_HTTP_PORT);
 function autoSideloadManifest(tls) {
+  const markerFile = (0, import_node_path2.resolve)(PROJECT_ROOT, ".sideloaded");
+  const pkgPath = (0, import_node_path2.resolve)(PROJECT_ROOT, "package.json");
+  let currentVersion = "unknown";
+  try {
+    const pkg = JSON.parse((0, import_node_fs2.readFileSync)(pkgPath, "utf8"));
+    currentVersion = pkg.version;
+  } catch {
+  }
+  try {
+    const markerVersion = (0, import_node_fs2.readFileSync)(markerFile, "utf8").trim();
+    if (markerVersion === currentVersion) {
+      console.error("[sideload] Add-in already installed (use `npm run sideload` to update)");
+      return;
+    }
+    console.error(`[sideload] Version changed (${markerVersion} \u2192 ${currentVersion}), re-sideloading`);
+  } catch {
+  }
   const wefDir = (0, import_node_path2.join)((0, import_node_os2.homedir)(), "Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef");
   const manifestName = tls ? "manifest-https.xml" : "manifest.xml";
   const src = (0, import_node_path2.resolve)(ADDIN_STATIC_DIR, manifestName);
@@ -35515,6 +35532,7 @@ function autoSideloadManifest(tls) {
     if (!(0, import_node_fs2.existsSync)(src)) return;
     (0, import_node_fs2.mkdirSync)(wefDir, { recursive: true });
     (0, import_node_fs2.copyFileSync)(src, dest);
+    (0, import_node_fs2.writeFileSync)(markerFile, currentVersion);
     console.error("[sideload] Add-in manifest installed for PowerPoint");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Rebuild stale `dist/index.cjs` from previous commit (fix/tcc-sideload-prompt shipped without rebuilding the bundle)
- Add pre-commit hook that fails if `server/` files are staged without `dist/index.cjs`
- Add CI step that verifies bundle freshness after tests
- Add Development Workflow section to CLAUDE.md (build, branch/PR, code quality conventions including TDD)

## Test plan
- [x] Pre-commit hook: stage only `server/` file → commit fails with clear message
- [x] Pre-commit hook: stage both `server/` and `dist/index.cjs` → commit succeeds
- [ ] CI: verify bundle freshness step passes on this PR
- [ ] CI: would fail if dist/index.cjs were stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)