### PR TITLE
fix: allow code review on PRs authored by claude[bot]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,9 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.author_association == 'OWNER'
+    if: >-
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.user.login == 'claude[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Claude's own PRs were skipping auto code review because `author_association != 'OWNER'`
- Add `claude[bot]` as trusted PR author alongside OWNER

## Test plan
- [ ] After merge, trigger `@claude implement` on an issue — the resulting PR should get auto-reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)