### PR TITLE
feat: add token weight guidance and tool selection hints to read tools

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -49598,7 +49598,7 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
   );
   server.tool(
     "get_presentation",
-    "Returns the structure of the currently open PowerPoint presentation including slide dimensions (slideWidth, slideHeight in points) and all slides with their IDs and shape summaries (count, names, types). Use this first to understand what's in the presentation before making changes.",
+    "Deck index (like list_slides): returns slide dimensions (slideWidth, slideHeight in points) and all slides with IDs and shape summaries (names, types). Scales with total shapes across all slides (~15 tokens/shape) \u2014 on a 20-slide deck this can be 3000+ tokens. Use to learn deck structure and slide indices. Do NOT use just to get slide dimensions \u2014 call get_slide on one slide instead.",
     {
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
@@ -49640,7 +49640,7 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
   );
   server.tool(
     "get_slide",
-    "Returns slide dimensions (slideWidth, slideHeight in points) and detailed information about all shapes on a specific slide, including text content, positions (left, top in points), sizes (width, height in points), and fill colors. Use slideIndex from get_presentation results (zero-based).",
+    "Detailed slide inspector: returns slide dimensions (slideWidth, slideHeight), and every shape with text content, positions, sizes, and fill colors (~80 tokens/shape). Use when you need to read or edit a specific slide. For just positions without text/fills, use list_slide_shapes instead.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
@@ -49703,7 +49703,7 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
   );
   server.tool(
     "list_slide_shapes",
-    "List all shapes on a slide with their IDs, types, and positions, plus slide dimensions (slideWidth, slideHeight in points). Lighter than get_slide \u2014 omits text and fill data.",
+    "Lightweight shape scanner: lists shape IDs, types, and positions on one slide, plus slide dimensions (~40 tokens/shape). Use when you only need shape layout/positions. For text content and fills, use get_slide instead.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
@@ -49751,7 +49751,7 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
   );
   server.tool(
     "get_slide_image",
-    "Captures a visual screenshot of a specific slide as a PNG image. Use this to SEE what a slide looks like \u2014 useful for verifying layout after changes or understanding content visually. Requires PowerPoint 16.96+ (PowerPointApi 1.8).",
+    "Slide screenshot: captures one slide as PNG image (~1000 tokens). Use to visually verify layout after changes. Do NOT use in a loop over all slides \u2014 use get_deck_overview instead.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
       width: external_exports3.number().int().min(1).max(4096).optional().describe(
@@ -49940,7 +49940,7 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
   );
   server.tool(
     "get_deck_overview",
-    "Returns a visual overview of all (or selected) slides in one call \u2014 thumbnails interleaved with text metadata. Much more efficient than calling get_slide + get_slide_image per slide. Use this to review or audit an entire presentation quickly.",
+    "Deck preview: batch overview of all/selected slides with optional thumbnails + text. With images: ~900 tokens/slide; text-only (includeImages=false): ~35 tokens/slide. Use for visual review or content audit. Do NOT use to inspect one slide \u2014 use get_slide or get_slide_image instead.",
     {
       slideRange: external_exports3.string().optional().describe('Slide indices to include, e.g. "0-5", "2,4,7", "0-2,5,8-10". Omit for all slides.'),
       imageWidth: external_exports3.number().int().min(120).max(1920).optional().describe("Thumbnail width in pixels. Default: 480. Height auto-calculated to preserve aspect ratio."),

--- a/server/tools.ts
+++ b/server/tools.ts
@@ -135,7 +135,7 @@ export function registerTools(
   // --- Tool: get_presentation ---
   server.tool(
     'get_presentation',
-    "Returns the structure of the currently open PowerPoint presentation including slide dimensions (slideWidth, slideHeight in points) and all slides with their IDs and shape summaries (count, names, types). Use this first to understand what's in the presentation before making changes.",
+    'Deck index (like list_slides): returns slide dimensions (slideWidth, slideHeight in points) and all slides with IDs and shape summaries (names, types). Scales with total shapes across all slides (~15 tokens/shape) — on a 20-slide deck this can be 3000+ tokens. Use to learn deck structure and slide indices. Do NOT use just to get slide dimensions — call get_slide on one slide instead.',
     {
       presentationId: z
         .string()
@@ -182,7 +182,7 @@ export function registerTools(
   // --- Tool: get_slide ---
   server.tool(
     'get_slide',
-    'Returns slide dimensions (slideWidth, slideHeight in points) and detailed information about all shapes on a specific slide, including text content, positions (left, top in points), sizes (width, height in points), and fill colors. Use slideIndex from get_presentation results (zero-based).',
+    'Detailed slide inspector: returns slide dimensions (slideWidth, slideHeight), and every shape with text content, positions, sizes, and fill colors (~80 tokens/shape). Use when you need to read or edit a specific slide. For just positions without text/fills, use list_slide_shapes instead.',
     {
       slideIndex: z.number().int().min(0).describe('Zero-based slide index from get_presentation results'),
       presentationId: z
@@ -250,7 +250,7 @@ export function registerTools(
   // --- Tool: list_slide_shapes ---
   server.tool(
     'list_slide_shapes',
-    'List all shapes on a slide with their IDs, types, and positions, plus slide dimensions (slideWidth, slideHeight in points). Lighter than get_slide — omits text and fill data.',
+    'Lightweight shape scanner: lists shape IDs, types, and positions on one slide, plus slide dimensions (~40 tokens/shape). Use when you only need shape layout/positions. For text content and fills, use get_slide instead.',
     {
       slideIndex: z.number().int().min(0).describe('Zero-based slide index from get_presentation results'),
       presentationId: z
@@ -303,7 +303,7 @@ export function registerTools(
   // --- Tool: get_slide_image ---
   server.tool(
     'get_slide_image',
-    'Captures a visual screenshot of a specific slide as a PNG image. Use this to SEE what a slide looks like — useful for verifying layout after changes or understanding content visually. Requires PowerPoint 16.96+ (PowerPointApi 1.8).',
+    'Slide screenshot: captures one slide as PNG image (~1000 tokens). Use to visually verify layout after changes. Do NOT use in a loop over all slides — use get_deck_overview instead.',
     {
       slideIndex: z.number().int().min(0).describe('Zero-based slide index from get_presentation results'),
       width: z
@@ -558,7 +558,7 @@ export function registerTools(
   // --- Tool: get_deck_overview ---
   server.tool(
     'get_deck_overview',
-    'Returns a visual overview of all (or selected) slides in one call — thumbnails interleaved with text metadata. Much more efficient than calling get_slide + get_slide_image per slide. Use this to review or audit an entire presentation quickly.',
+    'Deck preview: batch overview of all/selected slides with optional thumbnails + text. With images: ~900 tokens/slide; text-only (includeImages=false): ~35 tokens/slide. Use for visual review or content audit. Do NOT use to inspect one slide — use get_slide or get_slide_image instead.',
     {
       slideRange: z
         .string()

--- a/skills/powerpoint-live/SKILL.md
+++ b/skills/powerpoint-live/SKILL.md
@@ -21,10 +21,11 @@ When asked to enable or configure PowerPoint MCP in a project — follow the [se
 | Tool | Purpose | Key Parameters |
 |------|---------|---------------|
 | `list_presentations` | Discover connected presentations | — |
-| `get_presentation` | Get slide structure (indices, shape names/types) | `presentationId?` |
-| `get_slide` | Get detailed shapes (positions, text, colors) | `slideIndex`, `presentationId?` |
-| `get_slide_image` | Capture slide screenshot as PNG | `slideIndex`, `width?` (default 720), `presentationId?` |
-| `get_deck_overview` | Visual overview of all/selected slides in one call (thumbnails + text) | `slideRange?`, `imageWidth?` (default 480), `includeImages?`, `presentationId?` |
+| `get_presentation` | Deck index — all slides with shape names/types | `presentationId?` |
+| `get_slide` | Detailed slide inspector — shapes with text, positions, fills | `slideIndex`, `presentationId?` |
+| `list_slide_shapes` | Lightweight shape scanner — IDs + positions only | `slideIndex`, `presentationId?` |
+| `get_slide_image` | Slide screenshot as PNG | `slideIndex`, `width?` (default 720), `presentationId?` |
+| `get_deck_overview` | Deck preview — batch overview with optional thumbnails | `slideRange?`, `imageWidth?` (default 480), `includeImages?`, `presentationId?` |
 | `copy_slides` | Copy slides between two open presentations (data stays server-side) | `sourceSlideIndex`, `sourcePresentationId`, `destinationPresentationId`, `formatting?`, `targetSlideId?` |
 | `insert_image` | Insert image from file path, URL, or base64 data (data stays server-side for file/url) | `source`, `sourceType` (`file`/`url`/`base64`), `slideIndex?`, `left?`, `top?`, `width?`, `height?`, `presentationId?` |
 | `get_local_copy` | Get a local .pptx file path (passthrough for local files, exports cloud files to temp) | `presentationId?` |
@@ -44,6 +45,19 @@ When asked to enable or configure PowerPoint MCP in a project — follow the [se
 `presentationId` is required only when multiple presentations are connected. Get it from `list_presentations`.
 
 All positioning values are in **points** (1 pt = 1/72 inch). **Always read `slideWidth` and `slideHeight` from `get_presentation` or `get_slide` response** — never assume 960 × 540. Common sizes: 960×540 (standard 16:9), 1440×810 (widescreen), 960×720 (4:3).
+
+### Read Tool Selection — pick the lightest tool that gives you what you need
+
+| Tool | Scope | ~Cost | When to use | When NOT to use |
+|------|-------|-------|-------------|-----------------|
+| `list_slide_shapes` | 1 slide | ~40 tok/shape | Need shape positions/IDs for editing | Need text content or fills |
+| `get_slide` | 1 slide | ~80 tok/shape | Need full details (text, positions, fills) to read or edit | Just need positions — use `list_slide_shapes` |
+| `get_slide_image` | 1 slide | ~1000 tok | Visual verification after changes | Looping over all slides — use `get_deck_overview` |
+| `get_presentation` | All slides | ~15 tok/shape | Need deck structure and slide indices | Just need dimensions — call `get_slide` on one slide |
+| `get_deck_overview` text-only | All slides | ~35 tok/slide | Content audit, find which slide has what | Need shape positions or fills |
+| `get_deck_overview` + images | All slides | ~900 tok/slide | Visual audit of entire deck | Just need one slide — use `get_slide_image` |
+
+**Example**: a 20-slide deck with ~200 total shapes: `get_presentation` ≈ 3000 tokens, `get_deck_overview` text-only ≈ 700 tokens, `get_deck_overview` with images ≈ 18000 tokens. Always prefer the lightest option.
 
 ### Tool Return Values
 


### PR DESCRIPTION
## Summary
- Tool descriptions now include token weight estimates (~15/~40/~80 tokens/shape) and explicit DO/DON'T usage hints
- Skill adds a selection table: tool, scope, cost, when to use, when NOT to use
- Agent can now pick the lightest tool for the job instead of defaulting to `get_presentation`

Closes #65

## Test plan
- [x] `npm run check` passes (171/171 tests)
- [ ] Verify tool descriptions show correctly in MCP tool listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)