### PR TITLE
feat: add search_icons and insert_icon MCP tools

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -29,9 +29,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../../../node_modules/ajv/dist/compile/codegen/code.js
+// node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
-  "../../../node_modules/ajv/dist/compile/codegen/code.js"(exports2) {
+  "node_modules/ajv/dist/compile/codegen/code.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.regexpCode = exports2.getEsmExportName = exports2.getProperty = exports2.safeStringify = exports2.stringify = exports2.strConcat = exports2.addCodeArg = exports2.str = exports2._ = exports2.nil = exports2._Code = exports2.Name = exports2.IDENTIFIER = exports2._CodeOrName = void 0;
@@ -183,9 +183,9 @@ var require_code = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/codegen/scope.js
+// node_modules/ajv/dist/compile/codegen/scope.js
 var require_scope = __commonJS({
-  "../../../node_modules/ajv/dist/compile/codegen/scope.js"(exports2) {
+  "node_modules/ajv/dist/compile/codegen/scope.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.ValueScope = exports2.ValueScopeName = exports2.Scope = exports2.varKinds = exports2.UsedValueState = void 0;
@@ -328,9 +328,9 @@ var require_scope = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/codegen/index.js
+// node_modules/ajv/dist/compile/codegen/index.js
 var require_codegen = __commonJS({
-  "../../../node_modules/ajv/dist/compile/codegen/index.js"(exports2) {
+  "node_modules/ajv/dist/compile/codegen/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.or = exports2.and = exports2.not = exports2.CodeGen = exports2.operators = exports2.varKinds = exports2.ValueScopeName = exports2.ValueScope = exports2.Scope = exports2.Name = exports2.regexpCode = exports2.stringify = exports2.getProperty = exports2.nil = exports2.strConcat = exports2.str = exports2._ = void 0;
@@ -1048,9 +1048,9 @@ var require_codegen = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/util.js
+// node_modules/ajv/dist/compile/util.js
 var require_util = __commonJS({
-  "../../../node_modules/ajv/dist/compile/util.js"(exports2) {
+  "node_modules/ajv/dist/compile/util.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.checkStrictMode = exports2.getErrorPath = exports2.Type = exports2.useFunc = exports2.setEvaluated = exports2.evaluatedPropsToName = exports2.mergeEvaluated = exports2.eachItem = exports2.unescapeJsonPointer = exports2.escapeJsonPointer = exports2.escapeFragment = exports2.unescapeFragment = exports2.schemaRefOrVal = exports2.schemaHasRulesButRef = exports2.schemaHasRules = exports2.checkUnknownRules = exports2.alwaysValidSchema = exports2.toHash = void 0;
@@ -1215,9 +1215,9 @@ var require_util = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/names.js
+// node_modules/ajv/dist/compile/names.js
 var require_names = __commonJS({
-  "../../../node_modules/ajv/dist/compile/names.js"(exports2) {
+  "node_modules/ajv/dist/compile/names.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -1254,9 +1254,9 @@ var require_names = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/errors.js
+// node_modules/ajv/dist/compile/errors.js
 var require_errors = __commonJS({
-  "../../../node_modules/ajv/dist/compile/errors.js"(exports2) {
+  "node_modules/ajv/dist/compile/errors.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.extendErrors = exports2.resetErrorsCount = exports2.reportExtraError = exports2.reportError = exports2.keyword$DataError = exports2.keywordError = void 0;
@@ -1376,9 +1376,9 @@ var require_errors = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/validate/boolSchema.js
+// node_modules/ajv/dist/compile/validate/boolSchema.js
 var require_boolSchema = __commonJS({
-  "../../../node_modules/ajv/dist/compile/validate/boolSchema.js"(exports2) {
+  "node_modules/ajv/dist/compile/validate/boolSchema.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.boolOrEmptySchema = exports2.topBoolOrEmptySchema = void 0;
@@ -1427,9 +1427,9 @@ var require_boolSchema = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/rules.js
+// node_modules/ajv/dist/compile/rules.js
 var require_rules = __commonJS({
-  "../../../node_modules/ajv/dist/compile/rules.js"(exports2) {
+  "node_modules/ajv/dist/compile/rules.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getRules = exports2.isJSONType = void 0;
@@ -1458,9 +1458,9 @@ var require_rules = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/validate/applicability.js
+// node_modules/ajv/dist/compile/validate/applicability.js
 var require_applicability = __commonJS({
-  "../../../node_modules/ajv/dist/compile/validate/applicability.js"(exports2) {
+  "node_modules/ajv/dist/compile/validate/applicability.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.shouldUseRule = exports2.shouldUseGroup = exports2.schemaHasRulesForType = void 0;
@@ -1481,9 +1481,9 @@ var require_applicability = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/validate/dataType.js
+// node_modules/ajv/dist/compile/validate/dataType.js
 var require_dataType = __commonJS({
-  "../../../node_modules/ajv/dist/compile/validate/dataType.js"(exports2) {
+  "node_modules/ajv/dist/compile/validate/dataType.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.reportTypeError = exports2.checkDataTypes = exports2.checkDataType = exports2.coerceAndCheckDataType = exports2.getJSONTypes = exports2.getSchemaTypes = exports2.DataType = void 0;
@@ -1665,9 +1665,9 @@ var require_dataType = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/validate/defaults.js
+// node_modules/ajv/dist/compile/validate/defaults.js
 var require_defaults = __commonJS({
-  "../../../node_modules/ajv/dist/compile/validate/defaults.js"(exports2) {
+  "node_modules/ajv/dist/compile/validate/defaults.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.assignDefaults = void 0;
@@ -1702,9 +1702,9 @@ var require_defaults = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/code.js
+// node_modules/ajv/dist/vocabularies/code.js
 var require_code2 = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/code.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/code.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.validateUnion = exports2.validateArray = exports2.usePattern = exports2.callValidateCode = exports2.schemaProperties = exports2.allSchemaProperties = exports2.noPropertyInData = exports2.propertyInData = exports2.isOwnProperty = exports2.hasPropFunc = exports2.reportMissingProp = exports2.checkMissingProp = exports2.checkReportMissingProp = void 0;
@@ -1835,9 +1835,9 @@ var require_code2 = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/validate/keyword.js
+// node_modules/ajv/dist/compile/validate/keyword.js
 var require_keyword = __commonJS({
-  "../../../node_modules/ajv/dist/compile/validate/keyword.js"(exports2) {
+  "node_modules/ajv/dist/compile/validate/keyword.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.validateKeywordUsage = exports2.validSchemaType = exports2.funcKeywordCode = exports2.macroKeywordCode = void 0;
@@ -1953,9 +1953,9 @@ var require_keyword = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/validate/subschema.js
+// node_modules/ajv/dist/compile/validate/subschema.js
 var require_subschema = __commonJS({
-  "../../../node_modules/ajv/dist/compile/validate/subschema.js"(exports2) {
+  "node_modules/ajv/dist/compile/validate/subschema.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.extendSubschemaMode = exports2.extendSubschemaData = exports2.getSubschema = void 0;
@@ -2036,9 +2036,9 @@ var require_subschema = __commonJS({
   }
 });
 
-// ../../../node_modules/fast-deep-equal/index.js
+// node_modules/fast-deep-equal/index.js
 var require_fast_deep_equal = __commonJS({
-  "../../../node_modules/fast-deep-equal/index.js"(exports2, module2) {
+  "node_modules/fast-deep-equal/index.js"(exports2, module2) {
     "use strict";
     module2.exports = function equal(a, b) {
       if (a === b) return true;
@@ -2071,9 +2071,9 @@ var require_fast_deep_equal = __commonJS({
   }
 });
 
-// ../../../node_modules/json-schema-traverse/index.js
+// node_modules/json-schema-traverse/index.js
 var require_json_schema_traverse = __commonJS({
-  "../../../node_modules/json-schema-traverse/index.js"(exports2, module2) {
+  "node_modules/json-schema-traverse/index.js"(exports2, module2) {
     "use strict";
     var traverse = module2.exports = function(schema, opts, cb) {
       if (typeof opts == "function") {
@@ -2159,9 +2159,9 @@ var require_json_schema_traverse = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/resolve.js
+// node_modules/ajv/dist/compile/resolve.js
 var require_resolve = __commonJS({
-  "../../../node_modules/ajv/dist/compile/resolve.js"(exports2) {
+  "node_modules/ajv/dist/compile/resolve.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getSchemaRefs = exports2.resolveUrl = exports2.normalizeId = exports2._getFullPath = exports2.getFullPath = exports2.inlineRef = void 0;
@@ -2315,9 +2315,9 @@ var require_resolve = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/validate/index.js
+// node_modules/ajv/dist/compile/validate/index.js
 var require_validate = __commonJS({
-  "../../../node_modules/ajv/dist/compile/validate/index.js"(exports2) {
+  "node_modules/ajv/dist/compile/validate/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.getData = exports2.KeywordCxt = exports2.validateFunctionCode = void 0;
@@ -2823,9 +2823,9 @@ var require_validate = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/runtime/validation_error.js
+// node_modules/ajv/dist/runtime/validation_error.js
 var require_validation_error = __commonJS({
-  "../../../node_modules/ajv/dist/runtime/validation_error.js"(exports2) {
+  "node_modules/ajv/dist/runtime/validation_error.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var ValidationError = class extends Error {
@@ -2839,9 +2839,9 @@ var require_validation_error = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/ref_error.js
+// node_modules/ajv/dist/compile/ref_error.js
 var require_ref_error = __commonJS({
-  "../../../node_modules/ajv/dist/compile/ref_error.js"(exports2) {
+  "node_modules/ajv/dist/compile/ref_error.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var resolve_1 = require_resolve();
@@ -2856,9 +2856,9 @@ var require_ref_error = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/compile/index.js
+// node_modules/ajv/dist/compile/index.js
 var require_compile = __commonJS({
-  "../../../node_modules/ajv/dist/compile/index.js"(exports2) {
+  "node_modules/ajv/dist/compile/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.resolveSchema = exports2.getCompilingSchema = exports2.resolveRef = exports2.compileSchema = exports2.SchemaEnv = void 0;
@@ -3080,9 +3080,9 @@ var require_compile = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/refs/data.json
+// node_modules/ajv/dist/refs/data.json
 var require_data = __commonJS({
-  "../../../node_modules/ajv/dist/refs/data.json"(exports2, module2) {
+  "node_modules/ajv/dist/refs/data.json"(exports2, module2) {
     module2.exports = {
       $id: "https://raw.githubusercontent.com/ajv-validator/ajv/master/lib/refs/data.json#",
       description: "Meta-schema for $data reference (JSON AnySchema extension proposal)",
@@ -3099,9 +3099,9 @@ var require_data = __commonJS({
   }
 });
 
-// ../../../node_modules/fast-uri/lib/utils.js
+// node_modules/fast-uri/lib/utils.js
 var require_utils = __commonJS({
-  "../../../node_modules/fast-uri/lib/utils.js"(exports2, module2) {
+  "node_modules/fast-uri/lib/utils.js"(exports2, module2) {
     "use strict";
     var isUUID = RegExp.prototype.test.bind(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/iu);
     var isIPv4 = RegExp.prototype.test.bind(/^(?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]\d|\d)$/u);
@@ -3356,9 +3356,9 @@ var require_utils = __commonJS({
   }
 });
 
-// ../../../node_modules/fast-uri/lib/schemes.js
+// node_modules/fast-uri/lib/schemes.js
 var require_schemes = __commonJS({
-  "../../../node_modules/fast-uri/lib/schemes.js"(exports2, module2) {
+  "node_modules/fast-uri/lib/schemes.js"(exports2, module2) {
     "use strict";
     var { isUUID } = require_utils();
     var URN_REG = /([\da-z][\d\-a-z]{0,31}):((?:[\w!$'()*+,\-.:;=@]|%[\da-f]{2})+)/iu;
@@ -3566,9 +3566,9 @@ var require_schemes = __commonJS({
   }
 });
 
-// ../../../node_modules/fast-uri/index.js
+// node_modules/fast-uri/index.js
 var require_fast_uri = __commonJS({
-  "../../../node_modules/fast-uri/index.js"(exports2, module2) {
+  "node_modules/fast-uri/index.js"(exports2, module2) {
     "use strict";
     var { normalizeIPv6, removeDotSegments, recomposeAuthority, normalizeComponentEncoding, isIPv4, nonSimpleDomain } = require_utils();
     var { SCHEMES, getSchemeHandler } = require_schemes();
@@ -3821,9 +3821,9 @@ var require_fast_uri = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/runtime/uri.js
+// node_modules/ajv/dist/runtime/uri.js
 var require_uri = __commonJS({
-  "../../../node_modules/ajv/dist/runtime/uri.js"(exports2) {
+  "node_modules/ajv/dist/runtime/uri.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var uri = require_fast_uri();
@@ -3832,9 +3832,9 @@ var require_uri = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/core.js
+// node_modules/ajv/dist/core.js
 var require_core = __commonJS({
-  "../../../node_modules/ajv/dist/core.js"(exports2) {
+  "node_modules/ajv/dist/core.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.CodeGen = exports2.Name = exports2.nil = exports2.stringify = exports2.str = exports2._ = exports2.KeywordCxt = void 0;
@@ -4443,9 +4443,9 @@ var require_core = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/core/id.js
+// node_modules/ajv/dist/vocabularies/core/id.js
 var require_id = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/core/id.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/core/id.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var def = {
@@ -4458,9 +4458,9 @@ var require_id = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/core/ref.js
+// node_modules/ajv/dist/vocabularies/core/ref.js
 var require_ref = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/core/ref.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/core/ref.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.callRef = exports2.getValidate = void 0;
@@ -4580,9 +4580,9 @@ var require_ref = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/core/index.js
+// node_modules/ajv/dist/vocabularies/core/index.js
 var require_core2 = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/core/index.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/core/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var id_1 = require_id();
@@ -4601,9 +4601,9 @@ var require_core2 = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/limitNumber.js
+// node_modules/ajv/dist/vocabularies/validation/limitNumber.js
 var require_limitNumber = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/limitNumber.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4633,9 +4633,9 @@ var require_limitNumber = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/multipleOf.js
+// node_modules/ajv/dist/vocabularies/validation/multipleOf.js
 var require_multipleOf = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/multipleOf.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4661,9 +4661,9 @@ var require_multipleOf = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/runtime/ucs2length.js
+// node_modules/ajv/dist/runtime/ucs2length.js
 var require_ucs2length = __commonJS({
-  "../../../node_modules/ajv/dist/runtime/ucs2length.js"(exports2) {
+  "node_modules/ajv/dist/runtime/ucs2length.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     function ucs2length(str) {
@@ -4687,9 +4687,9 @@ var require_ucs2length = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/limitLength.js
+// node_modules/ajv/dist/vocabularies/validation/limitLength.js
 var require_limitLength = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/limitLength.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4719,9 +4719,9 @@ var require_limitLength = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/pattern.js
+// node_modules/ajv/dist/vocabularies/validation/pattern.js
 var require_pattern = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/pattern.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4747,9 +4747,9 @@ var require_pattern = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/limitProperties.js
+// node_modules/ajv/dist/vocabularies/validation/limitProperties.js
 var require_limitProperties = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/limitProperties.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4776,9 +4776,9 @@ var require_limitProperties = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/required.js
+// node_modules/ajv/dist/vocabularies/validation/required.js
 var require_required = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/required.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/required.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -4858,9 +4858,9 @@ var require_required = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/limitItems.js
+// node_modules/ajv/dist/vocabularies/validation/limitItems.js
 var require_limitItems = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/limitItems.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4887,9 +4887,9 @@ var require_limitItems = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/runtime/equal.js
+// node_modules/ajv/dist/runtime/equal.js
 var require_equal = __commonJS({
-  "../../../node_modules/ajv/dist/runtime/equal.js"(exports2) {
+  "node_modules/ajv/dist/runtime/equal.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var equal = require_fast_deep_equal();
@@ -4898,9 +4898,9 @@ var require_equal = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
+// node_modules/ajv/dist/vocabularies/validation/uniqueItems.js
 var require_uniqueItems = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/uniqueItems.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var dataType_1 = require_dataType();
@@ -4965,9 +4965,9 @@ var require_uniqueItems = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/const.js
+// node_modules/ajv/dist/vocabularies/validation/const.js
 var require_const = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/const.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/const.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -4994,9 +4994,9 @@ var require_const = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/enum.js
+// node_modules/ajv/dist/vocabularies/validation/enum.js
 var require_enum = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/enum.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/enum.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5043,9 +5043,9 @@ var require_enum = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/validation/index.js
+// node_modules/ajv/dist/vocabularies/validation/index.js
 var require_validation = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/validation/index.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/validation/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var limitNumber_1 = require_limitNumber();
@@ -5081,9 +5081,9 @@ var require_validation = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
+// node_modules/ajv/dist/vocabularies/applicator/additionalItems.js
 var require_additionalItems = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/additionalItems.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.validateAdditionalItems = void 0;
@@ -5134,9 +5134,9 @@ var require_additionalItems = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/items.js
+// node_modules/ajv/dist/vocabularies/applicator/items.js
 var require_items = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/items.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/items.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.validateTuple = void 0;
@@ -5191,9 +5191,9 @@ var require_items = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
+// node_modules/ajv/dist/vocabularies/applicator/prefixItems.js
 var require_prefixItems = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/prefixItems.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var items_1 = require_items();
@@ -5208,9 +5208,9 @@ var require_prefixItems = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/items2020.js
+// node_modules/ajv/dist/vocabularies/applicator/items2020.js
 var require_items2020 = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/items2020.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5243,9 +5243,9 @@ var require_items2020 = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/contains.js
+// node_modules/ajv/dist/vocabularies/applicator/contains.js
 var require_contains = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/contains.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5337,9 +5337,9 @@ var require_contains = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/dependencies.js
+// node_modules/ajv/dist/vocabularies/applicator/dependencies.js
 var require_dependencies = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/dependencies.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.validateSchemaDeps = exports2.validatePropertyDeps = exports2.error = void 0;
@@ -5431,9 +5431,9 @@ var require_dependencies = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
+// node_modules/ajv/dist/vocabularies/applicator/propertyNames.js
 var require_propertyNames = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/propertyNames.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5474,9 +5474,9 @@ var require_propertyNames = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
+// node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js
 var require_additionalProperties = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/additionalProperties.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5580,9 +5580,9 @@ var require_additionalProperties = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/properties.js
+// node_modules/ajv/dist/vocabularies/applicator/properties.js
 var require_properties = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/properties.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var validate_1 = require_validate();
@@ -5638,9 +5638,9 @@ var require_properties = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
+// node_modules/ajv/dist/vocabularies/applicator/patternProperties.js
 var require_patternProperties = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/patternProperties.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5712,9 +5712,9 @@ var require_patternProperties = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/not.js
+// node_modules/ajv/dist/vocabularies/applicator/not.js
 var require_not = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/not.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/not.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5743,9 +5743,9 @@ var require_not = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/anyOf.js
+// node_modules/ajv/dist/vocabularies/applicator/anyOf.js
 var require_anyOf = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/anyOf.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var code_1 = require_code2();
@@ -5760,9 +5760,9 @@ var require_anyOf = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/oneOf.js
+// node_modules/ajv/dist/vocabularies/applicator/oneOf.js
 var require_oneOf = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/oneOf.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5818,9 +5818,9 @@ var require_oneOf = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/allOf.js
+// node_modules/ajv/dist/vocabularies/applicator/allOf.js
 var require_allOf = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/allOf.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5845,9 +5845,9 @@ var require_allOf = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/if.js
+// node_modules/ajv/dist/vocabularies/applicator/if.js
 var require_if = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/if.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/if.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -5914,9 +5914,9 @@ var require_if = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/thenElse.js
+// node_modules/ajv/dist/vocabularies/applicator/thenElse.js
 var require_thenElse = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/thenElse.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var util_1 = require_util();
@@ -5932,9 +5932,9 @@ var require_thenElse = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/applicator/index.js
+// node_modules/ajv/dist/vocabularies/applicator/index.js
 var require_applicator = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/applicator/index.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/applicator/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var additionalItems_1 = require_additionalItems();
@@ -5980,9 +5980,9 @@ var require_applicator = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/format/format.js
+// node_modules/ajv/dist/vocabularies/format/format.js
 var require_format = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/format/format.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/format/format.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6070,9 +6070,9 @@ var require_format = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/format/index.js
+// node_modules/ajv/dist/vocabularies/format/index.js
 var require_format2 = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/format/index.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/format/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var format_1 = require_format();
@@ -6081,9 +6081,9 @@ var require_format2 = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/metadata.js
+// node_modules/ajv/dist/vocabularies/metadata.js
 var require_metadata = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/metadata.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/metadata.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.contentVocabulary = exports2.metadataVocabulary = void 0;
@@ -6104,9 +6104,9 @@ var require_metadata = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/draft7.js
+// node_modules/ajv/dist/vocabularies/draft7.js
 var require_draft7 = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/draft7.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/draft7.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var core_1 = require_core2();
@@ -6126,9 +6126,9 @@ var require_draft7 = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/discriminator/types.js
+// node_modules/ajv/dist/vocabularies/discriminator/types.js
 var require_types = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/discriminator/types.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.DiscrError = void 0;
@@ -6140,9 +6140,9 @@ var require_types = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/vocabularies/discriminator/index.js
+// node_modules/ajv/dist/vocabularies/discriminator/index.js
 var require_discriminator = __commonJS({
-  "../../../node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports2) {
+  "node_modules/ajv/dist/vocabularies/discriminator/index.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var codegen_1 = require_codegen();
@@ -6245,9 +6245,9 @@ var require_discriminator = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/refs/json-schema-draft-07.json
+// node_modules/ajv/dist/refs/json-schema-draft-07.json
 var require_json_schema_draft_07 = __commonJS({
-  "../../../node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports2, module2) {
+  "node_modules/ajv/dist/refs/json-schema-draft-07.json"(exports2, module2) {
     module2.exports = {
       $schema: "http://json-schema.org/draft-07/schema#",
       $id: "http://json-schema.org/draft-07/schema#",
@@ -6402,9 +6402,9 @@ var require_json_schema_draft_07 = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv/dist/ajv.js
+// node_modules/ajv/dist/ajv.js
 var require_ajv = __commonJS({
-  "../../../node_modules/ajv/dist/ajv.js"(exports2, module2) {
+  "node_modules/ajv/dist/ajv.js"(exports2, module2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.MissingRefError = exports2.ValidationError = exports2.CodeGen = exports2.Name = exports2.nil = exports2.stringify = exports2.str = exports2._ = exports2.KeywordCxt = exports2.Ajv = void 0;
@@ -6472,9 +6472,9 @@ var require_ajv = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv-formats/dist/formats.js
+// node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
-  "../../../node_modules/ajv-formats/dist/formats.js"(exports2) {
+  "node_modules/ajv-formats/dist/formats.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.formatNames = exports2.fastFormats = exports2.fullFormats = void 0;
@@ -6675,9 +6675,9 @@ var require_formats = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv-formats/dist/limit.js
+// node_modules/ajv-formats/dist/limit.js
 var require_limit = __commonJS({
-  "../../../node_modules/ajv-formats/dist/limit.js"(exports2) {
+  "node_modules/ajv-formats/dist/limit.js"(exports2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     exports2.formatLimitDefinition = void 0;
@@ -6747,9 +6747,9 @@ var require_limit = __commonJS({
   }
 });
 
-// ../../../node_modules/ajv-formats/dist/index.js
+// node_modules/ajv-formats/dist/index.js
 var require_dist = __commonJS({
-  "../../../node_modules/ajv-formats/dist/index.js"(exports2, module2) {
+  "node_modules/ajv-formats/dist/index.js"(exports2, module2) {
     "use strict";
     Object.defineProperty(exports2, "__esModule", { value: true });
     var formats_1 = require_formats();
@@ -6789,9 +6789,9 @@ var require_dist = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/constants.js
+// node_modules/ws/lib/constants.js
 var require_constants = __commonJS({
-  "../../../node_modules/ws/lib/constants.js"(exports2, module2) {
+  "node_modules/ws/lib/constants.js"(exports2, module2) {
     "use strict";
     var BINARY_TYPES = ["nodebuffer", "arraybuffer", "fragments"];
     var hasBlob = typeof Blob !== "undefined";
@@ -6812,9 +6812,9 @@ var require_constants = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/buffer-util.js
+// node_modules/ws/lib/buffer-util.js
 var require_buffer_util = __commonJS({
-  "../../../node_modules/ws/lib/buffer-util.js"(exports2, module2) {
+  "node_modules/ws/lib/buffer-util.js"(exports2, module2) {
     "use strict";
     var { EMPTY_BUFFER } = require_constants();
     var FastBuffer = Buffer[Symbol.species];
@@ -6887,9 +6887,9 @@ var require_buffer_util = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/limiter.js
+// node_modules/ws/lib/limiter.js
 var require_limiter = __commonJS({
-  "../../../node_modules/ws/lib/limiter.js"(exports2, module2) {
+  "node_modules/ws/lib/limiter.js"(exports2, module2) {
     "use strict";
     var kDone = /* @__PURE__ */ Symbol("kDone");
     var kRun = /* @__PURE__ */ Symbol("kRun");
@@ -6937,9 +6937,9 @@ var require_limiter = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/permessage-deflate.js
+// node_modules/ws/lib/permessage-deflate.js
 var require_permessage_deflate = __commonJS({
-  "../../../node_modules/ws/lib/permessage-deflate.js"(exports2, module2) {
+  "node_modules/ws/lib/permessage-deflate.js"(exports2, module2) {
     "use strict";
     var zlib = require("zlib");
     var bufferUtil = require_buffer_util();
@@ -7320,9 +7320,9 @@ var require_permessage_deflate = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/validation.js
+// node_modules/ws/lib/validation.js
 var require_validation2 = __commonJS({
-  "../../../node_modules/ws/lib/validation.js"(exports2, module2) {
+  "node_modules/ws/lib/validation.js"(exports2, module2) {
     "use strict";
     var { isUtf8 } = require("buffer");
     var { hasBlob } = require_constants();
@@ -7521,9 +7521,9 @@ var require_validation2 = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/receiver.js
+// node_modules/ws/lib/receiver.js
 var require_receiver = __commonJS({
-  "../../../node_modules/ws/lib/receiver.js"(exports2, module2) {
+  "node_modules/ws/lib/receiver.js"(exports2, module2) {
     "use strict";
     var { Writable } = require("stream");
     var PerMessageDeflate = require_permessage_deflate();
@@ -8113,9 +8113,9 @@ var require_receiver = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/sender.js
+// node_modules/ws/lib/sender.js
 var require_sender = __commonJS({
-  "../../../node_modules/ws/lib/sender.js"(exports2, module2) {
+  "node_modules/ws/lib/sender.js"(exports2, module2) {
     "use strict";
     var { Duplex } = require("stream");
     var { randomFillSync } = require("crypto");
@@ -8601,9 +8601,9 @@ var require_sender = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/event-target.js
+// node_modules/ws/lib/event-target.js
 var require_event_target = __commonJS({
-  "../../../node_modules/ws/lib/event-target.js"(exports2, module2) {
+  "node_modules/ws/lib/event-target.js"(exports2, module2) {
     "use strict";
     var { kForOnEventAttribute, kListener } = require_constants();
     var kCode = /* @__PURE__ */ Symbol("kCode");
@@ -8830,9 +8830,9 @@ var require_event_target = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/extension.js
+// node_modules/ws/lib/extension.js
 var require_extension = __commonJS({
-  "../../../node_modules/ws/lib/extension.js"(exports2, module2) {
+  "node_modules/ws/lib/extension.js"(exports2, module2) {
     "use strict";
     var { tokenChars } = require_validation2();
     function push(dest, name, elem) {
@@ -8983,9 +8983,9 @@ var require_extension = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/websocket.js
+// node_modules/ws/lib/websocket.js
 var require_websocket = __commonJS({
-  "../../../node_modules/ws/lib/websocket.js"(exports2, module2) {
+  "node_modules/ws/lib/websocket.js"(exports2, module2) {
     "use strict";
     var EventEmitter = require("events");
     var https = require("https");
@@ -9869,9 +9869,9 @@ var require_websocket = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/stream.js
+// node_modules/ws/lib/stream.js
 var require_stream = __commonJS({
-  "../../../node_modules/ws/lib/stream.js"(exports2, module2) {
+  "node_modules/ws/lib/stream.js"(exports2, module2) {
     "use strict";
     var WebSocket2 = require_websocket();
     var { Duplex } = require("stream");
@@ -9967,9 +9967,9 @@ var require_stream = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/subprotocol.js
+// node_modules/ws/lib/subprotocol.js
 var require_subprotocol = __commonJS({
-  "../../../node_modules/ws/lib/subprotocol.js"(exports2, module2) {
+  "node_modules/ws/lib/subprotocol.js"(exports2, module2) {
     "use strict";
     var { tokenChars } = require_validation2();
     function parse3(header) {
@@ -10012,9 +10012,9 @@ var require_subprotocol = __commonJS({
   }
 });
 
-// ../../../node_modules/ws/lib/websocket-server.js
+// node_modules/ws/lib/websocket-server.js
 var require_websocket_server = __commonJS({
-  "../../../node_modules/ws/lib/websocket-server.js"(exports2, module2) {
+  "node_modules/ws/lib/websocket-server.js"(exports2, module2) {
     "use strict";
     var EventEmitter = require("events");
     var http = require("http");
@@ -10405,9 +10405,9 @@ var require_websocket_server = __commonJS({
   }
 });
 
-// ../../../node_modules/@xmldom/xmldom/lib/conventions.js
+// node_modules/@xmldom/xmldom/lib/conventions.js
 var require_conventions = __commonJS({
-  "../../../node_modules/@xmldom/xmldom/lib/conventions.js"(exports2) {
+  "node_modules/@xmldom/xmldom/lib/conventions.js"(exports2) {
     "use strict";
     function find(list, predicate, ac) {
       if (ac === void 0) {
@@ -10544,9 +10544,9 @@ var require_conventions = __commonJS({
   }
 });
 
-// ../../../node_modules/@xmldom/xmldom/lib/dom.js
+// node_modules/@xmldom/xmldom/lib/dom.js
 var require_dom = __commonJS({
-  "../../../node_modules/@xmldom/xmldom/lib/dom.js"(exports2) {
+  "node_modules/@xmldom/xmldom/lib/dom.js"(exports2) {
     var conventions = require_conventions();
     var find = conventions.find;
     var NAMESPACE = conventions.NAMESPACE;
@@ -11979,9 +11979,9 @@ var require_dom = __commonJS({
   }
 });
 
-// ../../../node_modules/@xmldom/xmldom/lib/entities.js
+// node_modules/@xmldom/xmldom/lib/entities.js
 var require_entities = __commonJS({
-  "../../../node_modules/@xmldom/xmldom/lib/entities.js"(exports2) {
+  "node_modules/@xmldom/xmldom/lib/entities.js"(exports2) {
     "use strict";
     var freeze = require_conventions().freeze;
     exports2.XML_ENTITIES = freeze({
@@ -14122,9 +14122,9 @@ var require_entities = __commonJS({
   }
 });
 
-// ../../../node_modules/@xmldom/xmldom/lib/sax.js
+// node_modules/@xmldom/xmldom/lib/sax.js
 var require_sax = __commonJS({
-  "../../../node_modules/@xmldom/xmldom/lib/sax.js"(exports2) {
+  "node_modules/@xmldom/xmldom/lib/sax.js"(exports2) {
     var NAMESPACE = require_conventions().NAMESPACE;
     var nameStartChar = /[A-Z_a-z\xC0-\xD6\xD8-\xF6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/;
     var nameChar = new RegExp("[\\-\\.0-9" + nameStartChar.source.slice(1, -1) + "\\u00B7\\u0300-\\u036F\\u203F-\\u2040]");
@@ -14711,9 +14711,9 @@ var require_sax = __commonJS({
   }
 });
 
-// ../../../node_modules/@xmldom/xmldom/lib/dom-parser.js
+// node_modules/@xmldom/xmldom/lib/dom-parser.js
 var require_dom_parser = __commonJS({
-  "../../../node_modules/@xmldom/xmldom/lib/dom-parser.js"(exports2) {
+  "node_modules/@xmldom/xmldom/lib/dom-parser.js"(exports2) {
     var conventions = require_conventions();
     var dom = require_dom();
     var entities = require_entities();
@@ -14725,10 +14725,10 @@ var require_dom_parser = __commonJS({
     function normalizeLineEndings(input) {
       return input.replace(/\r[\n\u0085]/g, "\n").replace(/[\r\u0085\u2028]/g, "\n");
     }
-    function DOMParser3(options) {
+    function DOMParser2(options) {
       this.options = options || { locator: {} };
     }
-    DOMParser3.prototype.parseFromString = function(source, mimeType) {
+    DOMParser2.prototype.parseFromString = function(source, mimeType) {
       var options = this.options;
       var sax2 = new XMLReader();
       var domBuilder = options.domBuilder || new DOMHandler();
@@ -14923,13 +14923,13 @@ var require_dom_parser = __commonJS({
     }
     exports2.__DOMHandler = DOMHandler;
     exports2.normalizeLineEndings = normalizeLineEndings;
-    exports2.DOMParser = DOMParser3;
+    exports2.DOMParser = DOMParser2;
   }
 });
 
-// ../../../node_modules/@xmldom/xmldom/lib/index.js
+// node_modules/@xmldom/xmldom/lib/index.js
 var require_lib = __commonJS({
-  "../../../node_modules/@xmldom/xmldom/lib/index.js"(exports2) {
+  "node_modules/@xmldom/xmldom/lib/index.js"(exports2) {
     var dom = require_dom();
     exports2.DOMImplementation = dom.DOMImplementation;
     exports2.XMLSerializer = dom.XMLSerializer;
@@ -14937,9 +14937,9 @@ var require_lib = __commonJS({
   }
 });
 
-// ../../../node_modules/process-nextick-args/index.js
+// node_modules/process-nextick-args/index.js
 var require_process_nextick_args = __commonJS({
-  "../../../node_modules/process-nextick-args/index.js"(exports2, module2) {
+  "node_modules/process-nextick-args/index.js"(exports2, module2) {
     "use strict";
     if (typeof process === "undefined" || !process.version || process.version.indexOf("v0.") === 0 || process.version.indexOf("v1.") === 0 && process.version.indexOf("v1.8.") !== 0) {
       module2.exports = { nextTick };
@@ -14982,9 +14982,9 @@ var require_process_nextick_args = __commonJS({
   }
 });
 
-// ../../../node_modules/isarray/index.js
+// node_modules/isarray/index.js
 var require_isarray = __commonJS({
-  "../../../node_modules/isarray/index.js"(exports2, module2) {
+  "node_modules/isarray/index.js"(exports2, module2) {
     var toString = {}.toString;
     module2.exports = Array.isArray || function(arr) {
       return toString.call(arr) == "[object Array]";
@@ -14992,16 +14992,16 @@ var require_isarray = __commonJS({
   }
 });
 
-// ../../../node_modules/readable-stream/lib/internal/streams/stream.js
+// node_modules/readable-stream/lib/internal/streams/stream.js
 var require_stream2 = __commonJS({
-  "../../../node_modules/readable-stream/lib/internal/streams/stream.js"(exports2, module2) {
+  "node_modules/readable-stream/lib/internal/streams/stream.js"(exports2, module2) {
     module2.exports = require("stream");
   }
 });
 
-// ../../../node_modules/safe-buffer/index.js
+// node_modules/safe-buffer/index.js
 var require_safe_buffer = __commonJS({
-  "../../../node_modules/safe-buffer/index.js"(exports2, module2) {
+  "node_modules/safe-buffer/index.js"(exports2, module2) {
     var buffer = require("buffer");
     var Buffer2 = buffer.Buffer;
     function copyProps(src, dst) {
@@ -15056,9 +15056,9 @@ var require_safe_buffer = __commonJS({
   }
 });
 
-// ../../../node_modules/core-util-is/lib/util.js
+// node_modules/core-util-is/lib/util.js
 var require_util2 = __commonJS({
-  "../../../node_modules/core-util-is/lib/util.js"(exports2) {
+  "node_modules/core-util-is/lib/util.js"(exports2) {
     function isArray(arg) {
       if (Array.isArray) {
         return Array.isArray(arg);
@@ -15126,9 +15126,9 @@ var require_util2 = __commonJS({
   }
 });
 
-// ../../../node_modules/inherits/inherits_browser.js
+// node_modules/inherits/inherits_browser.js
 var require_inherits_browser = __commonJS({
-  "../../../node_modules/inherits/inherits_browser.js"(exports2, module2) {
+  "node_modules/inherits/inherits_browser.js"(exports2, module2) {
     if (typeof Object.create === "function") {
       module2.exports = function inherits(ctor, superCtor) {
         if (superCtor) {
@@ -15158,9 +15158,9 @@ var require_inherits_browser = __commonJS({
   }
 });
 
-// ../../../node_modules/inherits/inherits.js
+// node_modules/inherits/inherits.js
 var require_inherits = __commonJS({
-  "../../../node_modules/inherits/inherits.js"(exports2, module2) {
+  "node_modules/inherits/inherits.js"(exports2, module2) {
     try {
       util2 = require("util");
       if (typeof util2.inherits !== "function") throw "";
@@ -15172,9 +15172,9 @@ var require_inherits = __commonJS({
   }
 });
 
-// ../../../node_modules/readable-stream/lib/internal/streams/BufferList.js
+// node_modules/readable-stream/lib/internal/streams/BufferList.js
 var require_BufferList = __commonJS({
-  "../../../node_modules/readable-stream/lib/internal/streams/BufferList.js"(exports2, module2) {
+  "node_modules/readable-stream/lib/internal/streams/BufferList.js"(exports2, module2) {
     "use strict";
     function _classCallCheck(instance, Constructor) {
       if (!(instance instanceof Constructor)) {
@@ -15218,7 +15218,7 @@ var require_BufferList = __commonJS({
         this.head = this.tail = null;
         this.length = 0;
       };
-      BufferList.prototype.join = function join3(s) {
+      BufferList.prototype.join = function join4(s) {
         if (this.length === 0) return "";
         var p = this.head;
         var ret = "" + p.data;
@@ -15250,9 +15250,9 @@ var require_BufferList = __commonJS({
   }
 });
 
-// ../../../node_modules/readable-stream/lib/internal/streams/destroy.js
+// node_modules/readable-stream/lib/internal/streams/destroy.js
 var require_destroy = __commonJS({
-  "../../../node_modules/readable-stream/lib/internal/streams/destroy.js"(exports2, module2) {
+  "node_modules/readable-stream/lib/internal/streams/destroy.js"(exports2, module2) {
     "use strict";
     var pna = require_process_nextick_args();
     function destroy(err, cb) {
@@ -15319,16 +15319,16 @@ var require_destroy = __commonJS({
   }
 });
 
-// ../../../node_modules/util-deprecate/node.js
+// node_modules/util-deprecate/node.js
 var require_node = __commonJS({
-  "../../../node_modules/util-deprecate/node.js"(exports2, module2) {
+  "node_modules/util-deprecate/node.js"(exports2, module2) {
     module2.exports = require("util").deprecate;
   }
 });
 
-// ../../../node_modules/readable-stream/lib/_stream_writable.js
+// node_modules/readable-stream/lib/_stream_writable.js
 var require_stream_writable = __commonJS({
-  "../../../node_modules/readable-stream/lib/_stream_writable.js"(exports2, module2) {
+  "node_modules/readable-stream/lib/_stream_writable.js"(exports2, module2) {
     "use strict";
     var pna = require_process_nextick_args();
     module2.exports = Writable;
@@ -15766,9 +15766,9 @@ var require_stream_writable = __commonJS({
   }
 });
 
-// ../../../node_modules/readable-stream/lib/_stream_duplex.js
+// node_modules/readable-stream/lib/_stream_duplex.js
 var require_stream_duplex = __commonJS({
-  "../../../node_modules/readable-stream/lib/_stream_duplex.js"(exports2, module2) {
+  "node_modules/readable-stream/lib/_stream_duplex.js"(exports2, module2) {
     "use strict";
     var pna = require_process_nextick_args();
     var objectKeys = Object.keys || function(obj) {
@@ -15843,9 +15843,9 @@ var require_stream_duplex = __commonJS({
   }
 });
 
-// ../../../node_modules/string_decoder/lib/string_decoder.js
+// node_modules/string_decoder/lib/string_decoder.js
 var require_string_decoder = __commonJS({
-  "../../../node_modules/string_decoder/lib/string_decoder.js"(exports2) {
+  "node_modules/string_decoder/lib/string_decoder.js"(exports2) {
     "use strict";
     var Buffer2 = require_safe_buffer().Buffer;
     var isEncoding = Buffer2.isEncoding || function(encoding) {
@@ -16081,9 +16081,9 @@ var require_string_decoder = __commonJS({
   }
 });
 
-// ../../../node_modules/readable-stream/lib/_stream_readable.js
+// node_modules/readable-stream/lib/_stream_readable.js
 var require_stream_readable = __commonJS({
-  "../../../node_modules/readable-stream/lib/_stream_readable.js"(exports2, module2) {
+  "node_modules/readable-stream/lib/_stream_readable.js"(exports2, module2) {
     "use strict";
     var pna = require_process_nextick_args();
     module2.exports = Readable2;
@@ -16767,9 +16767,9 @@ var require_stream_readable = __commonJS({
   }
 });
 
-// ../../../node_modules/readable-stream/lib/_stream_transform.js
+// node_modules/readable-stream/lib/_stream_transform.js
 var require_stream_transform = __commonJS({
-  "../../../node_modules/readable-stream/lib/_stream_transform.js"(exports2, module2) {
+  "node_modules/readable-stream/lib/_stream_transform.js"(exports2, module2) {
     "use strict";
     module2.exports = Transform;
     var Duplex = require_stream_duplex();
@@ -16867,9 +16867,9 @@ var require_stream_transform = __commonJS({
   }
 });
 
-// ../../../node_modules/readable-stream/lib/_stream_passthrough.js
+// node_modules/readable-stream/lib/_stream_passthrough.js
 var require_stream_passthrough = __commonJS({
-  "../../../node_modules/readable-stream/lib/_stream_passthrough.js"(exports2, module2) {
+  "node_modules/readable-stream/lib/_stream_passthrough.js"(exports2, module2) {
     "use strict";
     module2.exports = PassThrough;
     var Transform = require_stream_transform();
@@ -16886,9 +16886,9 @@ var require_stream_passthrough = __commonJS({
   }
 });
 
-// ../../../node_modules/readable-stream/readable.js
+// node_modules/readable-stream/readable.js
 var require_readable = __commonJS({
-  "../../../node_modules/readable-stream/readable.js"(exports2, module2) {
+  "node_modules/readable-stream/readable.js"(exports2, module2) {
     var Stream = require("stream");
     if (process.env.READABLE_STREAM === "disable" && Stream) {
       module2.exports = Stream;
@@ -16911,9 +16911,9 @@ var require_readable = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/support.js
+// node_modules/jszip/lib/support.js
 var require_support = __commonJS({
-  "../../../node_modules/jszip/lib/support.js"(exports2) {
+  "node_modules/jszip/lib/support.js"(exports2) {
     "use strict";
     exports2.base64 = true;
     exports2.array = true;
@@ -16951,9 +16951,9 @@ var require_support = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/base64.js
+// node_modules/jszip/lib/base64.js
 var require_base64 = __commonJS({
-  "../../../node_modules/jszip/lib/base64.js"(exports2) {
+  "node_modules/jszip/lib/base64.js"(exports2) {
     "use strict";
     var utils = require_utils2();
     var support = require_support();
@@ -17028,9 +17028,9 @@ var require_base64 = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/nodejsUtils.js
+// node_modules/jszip/lib/nodejsUtils.js
 var require_nodejsUtils = __commonJS({
-  "../../../node_modules/jszip/lib/nodejsUtils.js"(exports2, module2) {
+  "node_modules/jszip/lib/nodejsUtils.js"(exports2, module2) {
     "use strict";
     module2.exports = {
       /**
@@ -17084,9 +17084,9 @@ var require_nodejsUtils = __commonJS({
   }
 });
 
-// ../../../node_modules/immediate/lib/index.js
+// node_modules/immediate/lib/index.js
 var require_lib2 = __commonJS({
-  "../../../node_modules/immediate/lib/index.js"(exports2, module2) {
+  "node_modules/immediate/lib/index.js"(exports2, module2) {
     "use strict";
     var Mutation = global.MutationObserver || global.WebKitMutationObserver;
     var scheduleDrain;
@@ -17158,9 +17158,9 @@ var require_lib2 = __commonJS({
   }
 });
 
-// ../../../node_modules/lie/lib/index.js
+// node_modules/lie/lib/index.js
 var require_lib3 = __commonJS({
-  "../../../node_modules/lie/lib/index.js"(exports2, module2) {
+  "node_modules/lie/lib/index.js"(exports2, module2) {
     "use strict";
     var immediate = require_lib2();
     function INTERNAL() {
@@ -17428,9 +17428,9 @@ var require_lib3 = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/external.js
+// node_modules/jszip/lib/external.js
 var require_external = __commonJS({
-  "../../../node_modules/jszip/lib/external.js"(exports2, module2) {
+  "node_modules/jszip/lib/external.js"(exports2, module2) {
     "use strict";
     var ES6Promise = null;
     if (typeof Promise !== "undefined") {
@@ -17444,9 +17444,9 @@ var require_external = __commonJS({
   }
 });
 
-// ../../../node_modules/setimmediate/setImmediate.js
+// node_modules/setimmediate/setImmediate.js
 var require_setImmediate = __commonJS({
-  "../../../node_modules/setimmediate/setImmediate.js"(exports2) {
+  "node_modules/setimmediate/setImmediate.js"(exports2) {
     (function(global2, undefined2) {
       "use strict";
       if (global2.setImmediate) {
@@ -17592,9 +17592,9 @@ var require_setImmediate = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/utils.js
+// node_modules/jszip/lib/utils.js
 var require_utils2 = __commonJS({
-  "../../../node_modules/jszip/lib/utils.js"(exports2) {
+  "node_modules/jszip/lib/utils.js"(exports2) {
     "use strict";
     var support = require_support();
     var base643 = require_base64();
@@ -17917,9 +17917,9 @@ var require_utils2 = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/stream/GenericWorker.js
+// node_modules/jszip/lib/stream/GenericWorker.js
 var require_GenericWorker = __commonJS({
-  "../../../node_modules/jszip/lib/stream/GenericWorker.js"(exports2, module2) {
+  "node_modules/jszip/lib/stream/GenericWorker.js"(exports2, module2) {
     "use strict";
     function GenericWorker(name) {
       this.name = name || "default";
@@ -18144,9 +18144,9 @@ var require_GenericWorker = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/utf8.js
+// node_modules/jszip/lib/utf8.js
 var require_utf8 = __commonJS({
-  "../../../node_modules/jszip/lib/utf8.js"(exports2) {
+  "node_modules/jszip/lib/utf8.js"(exports2) {
     "use strict";
     var utils = require_utils2();
     var support = require_support();
@@ -18334,9 +18334,9 @@ var require_utf8 = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/stream/ConvertWorker.js
+// node_modules/jszip/lib/stream/ConvertWorker.js
 var require_ConvertWorker = __commonJS({
-  "../../../node_modules/jszip/lib/stream/ConvertWorker.js"(exports2, module2) {
+  "node_modules/jszip/lib/stream/ConvertWorker.js"(exports2, module2) {
     "use strict";
     var GenericWorker = require_GenericWorker();
     var utils = require_utils2();
@@ -18355,9 +18355,9 @@ var require_ConvertWorker = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/nodejs/NodejsStreamOutputAdapter.js
+// node_modules/jszip/lib/nodejs/NodejsStreamOutputAdapter.js
 var require_NodejsStreamOutputAdapter = __commonJS({
-  "../../../node_modules/jszip/lib/nodejs/NodejsStreamOutputAdapter.js"(exports2, module2) {
+  "node_modules/jszip/lib/nodejs/NodejsStreamOutputAdapter.js"(exports2, module2) {
     "use strict";
     var Readable2 = require_readable().Readable;
     var utils = require_utils2();
@@ -18386,9 +18386,9 @@ var require_NodejsStreamOutputAdapter = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/stream/StreamHelper.js
+// node_modules/jszip/lib/stream/StreamHelper.js
 var require_StreamHelper = __commonJS({
-  "../../../node_modules/jszip/lib/stream/StreamHelper.js"(exports2, module2) {
+  "node_modules/jszip/lib/stream/StreamHelper.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     var ConvertWorker = require_ConvertWorker();
@@ -18546,9 +18546,9 @@ var require_StreamHelper = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/defaults.js
+// node_modules/jszip/lib/defaults.js
 var require_defaults2 = __commonJS({
-  "../../../node_modules/jszip/lib/defaults.js"(exports2) {
+  "node_modules/jszip/lib/defaults.js"(exports2) {
     "use strict";
     exports2.base64 = false;
     exports2.binary = false;
@@ -18563,9 +18563,9 @@ var require_defaults2 = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/stream/DataWorker.js
+// node_modules/jszip/lib/stream/DataWorker.js
 var require_DataWorker = __commonJS({
-  "../../../node_modules/jszip/lib/stream/DataWorker.js"(exports2, module2) {
+  "node_modules/jszip/lib/stream/DataWorker.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     var GenericWorker = require_GenericWorker();
@@ -18651,9 +18651,9 @@ var require_DataWorker = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/crc32.js
+// node_modules/jszip/lib/crc32.js
 var require_crc32 = __commonJS({
-  "../../../node_modules/jszip/lib/crc32.js"(exports2, module2) {
+  "node_modules/jszip/lib/crc32.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     function makeTable() {
@@ -18698,9 +18698,9 @@ var require_crc32 = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/stream/Crc32Probe.js
+// node_modules/jszip/lib/stream/Crc32Probe.js
 var require_Crc32Probe = __commonJS({
-  "../../../node_modules/jszip/lib/stream/Crc32Probe.js"(exports2, module2) {
+  "node_modules/jszip/lib/stream/Crc32Probe.js"(exports2, module2) {
     "use strict";
     var GenericWorker = require_GenericWorker();
     var crc32 = require_crc32();
@@ -18718,9 +18718,9 @@ var require_Crc32Probe = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/stream/DataLengthProbe.js
+// node_modules/jszip/lib/stream/DataLengthProbe.js
 var require_DataLengthProbe = __commonJS({
-  "../../../node_modules/jszip/lib/stream/DataLengthProbe.js"(exports2, module2) {
+  "node_modules/jszip/lib/stream/DataLengthProbe.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     var GenericWorker = require_GenericWorker();
@@ -18741,9 +18741,9 @@ var require_DataLengthProbe = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/compressedObject.js
+// node_modules/jszip/lib/compressedObject.js
 var require_compressedObject = __commonJS({
-  "../../../node_modules/jszip/lib/compressedObject.js"(exports2, module2) {
+  "node_modules/jszip/lib/compressedObject.js"(exports2, module2) {
     "use strict";
     var external = require_external();
     var DataWorker = require_DataWorker();
@@ -18786,9 +18786,9 @@ var require_compressedObject = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/zipObject.js
+// node_modules/jszip/lib/zipObject.js
 var require_zipObject = __commonJS({
-  "../../../node_modules/jszip/lib/zipObject.js"(exports2, module2) {
+  "node_modules/jszip/lib/zipObject.js"(exports2, module2) {
     "use strict";
     var StreamHelper = require_StreamHelper();
     var DataWorker = require_DataWorker();
@@ -18903,9 +18903,9 @@ var require_zipObject = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/utils/common.js
+// node_modules/pako/lib/utils/common.js
 var require_common = __commonJS({
-  "../../../node_modules/pako/lib/utils/common.js"(exports2) {
+  "node_modules/pako/lib/utils/common.js"(exports2) {
     "use strict";
     var TYPED_OK = typeof Uint8Array !== "undefined" && typeof Uint16Array !== "undefined" && typeof Int32Array !== "undefined";
     function _has(obj, key) {
@@ -18994,9 +18994,9 @@ var require_common = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/trees.js
+// node_modules/pako/lib/zlib/trees.js
 var require_trees = __commonJS({
-  "../../../node_modules/pako/lib/zlib/trees.js"(exports2) {
+  "node_modules/pako/lib/zlib/trees.js"(exports2) {
     "use strict";
     var utils = require_common();
     var Z_FIXED = 4;
@@ -19636,9 +19636,9 @@ var require_trees = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/adler32.js
+// node_modules/pako/lib/zlib/adler32.js
 var require_adler32 = __commonJS({
-  "../../../node_modules/pako/lib/zlib/adler32.js"(exports2, module2) {
+  "node_modules/pako/lib/zlib/adler32.js"(exports2, module2) {
     "use strict";
     function adler32(adler, buf, len, pos) {
       var s1 = adler & 65535 | 0, s2 = adler >>> 16 & 65535 | 0, n = 0;
@@ -19658,9 +19658,9 @@ var require_adler32 = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/crc32.js
+// node_modules/pako/lib/zlib/crc32.js
 var require_crc322 = __commonJS({
-  "../../../node_modules/pako/lib/zlib/crc32.js"(exports2, module2) {
+  "node_modules/pako/lib/zlib/crc32.js"(exports2, module2) {
     "use strict";
     function makeTable() {
       var c, table = [];
@@ -19686,9 +19686,9 @@ var require_crc322 = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/messages.js
+// node_modules/pako/lib/zlib/messages.js
 var require_messages = __commonJS({
-  "../../../node_modules/pako/lib/zlib/messages.js"(exports2, module2) {
+  "node_modules/pako/lib/zlib/messages.js"(exports2, module2) {
     "use strict";
     module2.exports = {
       2: "need dictionary",
@@ -19713,9 +19713,9 @@ var require_messages = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/deflate.js
+// node_modules/pako/lib/zlib/deflate.js
 var require_deflate = __commonJS({
-  "../../../node_modules/pako/lib/zlib/deflate.js"(exports2) {
+  "node_modules/pako/lib/zlib/deflate.js"(exports2) {
     "use strict";
     var utils = require_common();
     var trees = require_trees();
@@ -20762,9 +20762,9 @@ var require_deflate = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/utils/strings.js
+// node_modules/pako/lib/utils/strings.js
 var require_strings = __commonJS({
-  "../../../node_modules/pako/lib/utils/strings.js"(exports2) {
+  "node_modules/pako/lib/utils/strings.js"(exports2) {
     "use strict";
     var utils = require_common();
     var STR_APPLY_OK = true;
@@ -20904,9 +20904,9 @@ var require_strings = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/zstream.js
+// node_modules/pako/lib/zlib/zstream.js
 var require_zstream = __commonJS({
-  "../../../node_modules/pako/lib/zlib/zstream.js"(exports2, module2) {
+  "node_modules/pako/lib/zlib/zstream.js"(exports2, module2) {
     "use strict";
     function ZStream() {
       this.input = null;
@@ -20926,9 +20926,9 @@ var require_zstream = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/deflate.js
+// node_modules/pako/lib/deflate.js
 var require_deflate2 = __commonJS({
-  "../../../node_modules/pako/lib/deflate.js"(exports2) {
+  "node_modules/pako/lib/deflate.js"(exports2) {
     "use strict";
     var zlib_deflate = require_deflate();
     var utils = require_common();
@@ -21087,9 +21087,9 @@ var require_deflate2 = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/inffast.js
+// node_modules/pako/lib/zlib/inffast.js
 var require_inffast = __commonJS({
-  "../../../node_modules/pako/lib/zlib/inffast.js"(exports2, module2) {
+  "node_modules/pako/lib/zlib/inffast.js"(exports2, module2) {
     "use strict";
     var BAD = 30;
     var TYPE = 12;
@@ -21316,9 +21316,9 @@ var require_inffast = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/inftrees.js
+// node_modules/pako/lib/zlib/inftrees.js
 var require_inftrees = __commonJS({
-  "../../../node_modules/pako/lib/zlib/inftrees.js"(exports2, module2) {
+  "node_modules/pako/lib/zlib/inftrees.js"(exports2, module2) {
     "use strict";
     var utils = require_common();
     var MAXBITS = 15;
@@ -21632,9 +21632,9 @@ var require_inftrees = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/inflate.js
+// node_modules/pako/lib/zlib/inflate.js
 var require_inflate = __commonJS({
-  "../../../node_modules/pako/lib/zlib/inflate.js"(exports2) {
+  "node_modules/pako/lib/zlib/inflate.js"(exports2) {
     "use strict";
     var utils = require_common();
     var adler32 = require_adler32();
@@ -22871,9 +22871,9 @@ var require_inflate = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/constants.js
+// node_modules/pako/lib/zlib/constants.js
 var require_constants2 = __commonJS({
-  "../../../node_modules/pako/lib/zlib/constants.js"(exports2, module2) {
+  "node_modules/pako/lib/zlib/constants.js"(exports2, module2) {
     "use strict";
     module2.exports = {
       /* Allowed flush values; see deflate() and inflate() below for details */
@@ -22918,9 +22918,9 @@ var require_constants2 = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/zlib/gzheader.js
+// node_modules/pako/lib/zlib/gzheader.js
 var require_gzheader = __commonJS({
-  "../../../node_modules/pako/lib/zlib/gzheader.js"(exports2, module2) {
+  "node_modules/pako/lib/zlib/gzheader.js"(exports2, module2) {
     "use strict";
     function GZheader() {
       this.text = 0;
@@ -22938,9 +22938,9 @@ var require_gzheader = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/lib/inflate.js
+// node_modules/pako/lib/inflate.js
 var require_inflate2 = __commonJS({
-  "../../../node_modules/pako/lib/inflate.js"(exports2) {
+  "node_modules/pako/lib/inflate.js"(exports2) {
     "use strict";
     var zlib_inflate = require_inflate();
     var utils = require_common();
@@ -23112,9 +23112,9 @@ var require_inflate2 = __commonJS({
   }
 });
 
-// ../../../node_modules/pako/index.js
+// node_modules/pako/index.js
 var require_pako = __commonJS({
-  "../../../node_modules/pako/index.js"(exports2, module2) {
+  "node_modules/pako/index.js"(exports2, module2) {
     "use strict";
     var assign = require_common().assign;
     var deflate = require_deflate2();
@@ -23126,9 +23126,9 @@ var require_pako = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/flate.js
+// node_modules/jszip/lib/flate.js
 var require_flate = __commonJS({
-  "../../../node_modules/jszip/lib/flate.js"(exports2) {
+  "node_modules/jszip/lib/flate.js"(exports2) {
     "use strict";
     var USE_TYPEDARRAY = typeof Uint8Array !== "undefined" && typeof Uint16Array !== "undefined" && typeof Uint32Array !== "undefined";
     var pako = require_pako();
@@ -23185,9 +23185,9 @@ var require_flate = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/compressions.js
+// node_modules/jszip/lib/compressions.js
 var require_compressions = __commonJS({
-  "../../../node_modules/jszip/lib/compressions.js"(exports2) {
+  "node_modules/jszip/lib/compressions.js"(exports2) {
     "use strict";
     var GenericWorker = require_GenericWorker();
     exports2.STORE = {
@@ -23203,9 +23203,9 @@ var require_compressions = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/signature.js
+// node_modules/jszip/lib/signature.js
 var require_signature = __commonJS({
-  "../../../node_modules/jszip/lib/signature.js"(exports2) {
+  "node_modules/jszip/lib/signature.js"(exports2) {
     "use strict";
     exports2.LOCAL_FILE_HEADER = "PK";
     exports2.CENTRAL_FILE_HEADER = "PK";
@@ -23216,9 +23216,9 @@ var require_signature = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/generate/ZipFileWorker.js
+// node_modules/jszip/lib/generate/ZipFileWorker.js
 var require_ZipFileWorker = __commonJS({
-  "../../../node_modules/jszip/lib/generate/ZipFileWorker.js"(exports2, module2) {
+  "node_modules/jszip/lib/generate/ZipFileWorker.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     var GenericWorker = require_GenericWorker();
@@ -23500,9 +23500,9 @@ var require_ZipFileWorker = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/generate/index.js
+// node_modules/jszip/lib/generate/index.js
 var require_generate = __commonJS({
-  "../../../node_modules/jszip/lib/generate/index.js"(exports2) {
+  "node_modules/jszip/lib/generate/index.js"(exports2) {
     "use strict";
     var compressions = require_compressions();
     var ZipFileWorker = require_ZipFileWorker();
@@ -23541,9 +23541,9 @@ var require_generate = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/nodejs/NodejsStreamInputAdapter.js
+// node_modules/jszip/lib/nodejs/NodejsStreamInputAdapter.js
 var require_NodejsStreamInputAdapter = __commonJS({
-  "../../../node_modules/jszip/lib/nodejs/NodejsStreamInputAdapter.js"(exports2, module2) {
+  "node_modules/jszip/lib/nodejs/NodejsStreamInputAdapter.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     var GenericWorker = require_GenericWorker();
@@ -23600,9 +23600,9 @@ var require_NodejsStreamInputAdapter = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/object.js
+// node_modules/jszip/lib/object.js
 var require_object = __commonJS({
-  "../../../node_modules/jszip/lib/object.js"(exports2, module2) {
+  "node_modules/jszip/lib/object.js"(exports2, module2) {
     "use strict";
     var utf8 = require_utf8();
     var utils = require_utils2();
@@ -23873,9 +23873,9 @@ var require_object = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/reader/DataReader.js
+// node_modules/jszip/lib/reader/DataReader.js
 var require_DataReader = __commonJS({
-  "../../../node_modules/jszip/lib/reader/DataReader.js"(exports2, module2) {
+  "node_modules/jszip/lib/reader/DataReader.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     function DataReader(data) {
@@ -23995,9 +23995,9 @@ var require_DataReader = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/reader/ArrayReader.js
+// node_modules/jszip/lib/reader/ArrayReader.js
 var require_ArrayReader = __commonJS({
-  "../../../node_modules/jszip/lib/reader/ArrayReader.js"(exports2, module2) {
+  "node_modules/jszip/lib/reader/ArrayReader.js"(exports2, module2) {
     "use strict";
     var DataReader = require_DataReader();
     var utils = require_utils2();
@@ -24037,9 +24037,9 @@ var require_ArrayReader = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/reader/StringReader.js
+// node_modules/jszip/lib/reader/StringReader.js
 var require_StringReader = __commonJS({
-  "../../../node_modules/jszip/lib/reader/StringReader.js"(exports2, module2) {
+  "node_modules/jszip/lib/reader/StringReader.js"(exports2, module2) {
     "use strict";
     var DataReader = require_DataReader();
     var utils = require_utils2();
@@ -24067,9 +24067,9 @@ var require_StringReader = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/reader/Uint8ArrayReader.js
+// node_modules/jszip/lib/reader/Uint8ArrayReader.js
 var require_Uint8ArrayReader = __commonJS({
-  "../../../node_modules/jszip/lib/reader/Uint8ArrayReader.js"(exports2, module2) {
+  "node_modules/jszip/lib/reader/Uint8ArrayReader.js"(exports2, module2) {
     "use strict";
     var ArrayReader = require_ArrayReader();
     var utils = require_utils2();
@@ -24090,9 +24090,9 @@ var require_Uint8ArrayReader = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/reader/NodeBufferReader.js
+// node_modules/jszip/lib/reader/NodeBufferReader.js
 var require_NodeBufferReader = __commonJS({
-  "../../../node_modules/jszip/lib/reader/NodeBufferReader.js"(exports2, module2) {
+  "node_modules/jszip/lib/reader/NodeBufferReader.js"(exports2, module2) {
     "use strict";
     var Uint8ArrayReader = require_Uint8ArrayReader();
     var utils = require_utils2();
@@ -24110,9 +24110,9 @@ var require_NodeBufferReader = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/reader/readerFor.js
+// node_modules/jszip/lib/reader/readerFor.js
 var require_readerFor = __commonJS({
-  "../../../node_modules/jszip/lib/reader/readerFor.js"(exports2, module2) {
+  "node_modules/jszip/lib/reader/readerFor.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     var support = require_support();
@@ -24137,9 +24137,9 @@ var require_readerFor = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/zipEntry.js
+// node_modules/jszip/lib/zipEntry.js
 var require_zipEntry = __commonJS({
-  "../../../node_modules/jszip/lib/zipEntry.js"(exports2, module2) {
+  "node_modules/jszip/lib/zipEntry.js"(exports2, module2) {
     "use strict";
     var readerFor = require_readerFor();
     var utils = require_utils2();
@@ -24355,9 +24355,9 @@ var require_zipEntry = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/zipEntries.js
+// node_modules/jszip/lib/zipEntries.js
 var require_zipEntries = __commonJS({
-  "../../../node_modules/jszip/lib/zipEntries.js"(exports2, module2) {
+  "node_modules/jszip/lib/zipEntries.js"(exports2, module2) {
     "use strict";
     var readerFor = require_readerFor();
     var utils = require_utils2();
@@ -24553,9 +24553,9 @@ var require_zipEntries = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/load.js
+// node_modules/jszip/lib/load.js
 var require_load = __commonJS({
-  "../../../node_modules/jszip/lib/load.js"(exports2, module2) {
+  "node_modules/jszip/lib/load.js"(exports2, module2) {
     "use strict";
     var utils = require_utils2();
     var external = require_external();
@@ -24632,9 +24632,9 @@ var require_load = __commonJS({
   }
 });
 
-// ../../../node_modules/jszip/lib/index.js
+// node_modules/jszip/lib/index.js
 var require_lib4 = __commonJS({
-  "../../../node_modules/jszip/lib/index.js"(exports2, module2) {
+  "node_modules/jszip/lib/index.js"(exports2, module2) {
     "use strict";
     function JSZip2() {
       if (!(this instanceof JSZip2)) {
@@ -24671,14 +24671,14 @@ var require_lib4 = __commonJS({
 
 // server/index.ts
 var import_node_crypto2 = require("node:crypto");
-var import_node_fs2 = require("node:fs");
+var import_node_fs3 = require("node:fs");
 var import_node_http = require("node:http");
 var import_node_https = require("node:https");
 var import_node_os2 = require("node:os");
-var import_node_path2 = require("node:path");
-var import_node_url = require("node:url");
+var import_node_path3 = require("node:path");
+var import_node_url2 = require("node:url");
 
-// ../../../node_modules/zod/v3/helpers/util.js
+// node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -24812,7 +24812,7 @@ var getParsedType = (data) => {
   }
 };
 
-// ../../../node_modules/zod/v3/ZodError.js
+// node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -24926,7 +24926,7 @@ ZodError.create = (issues) => {
   return error48;
 };
 
-// ../../../node_modules/zod/v3/locales/en.js
+// node_modules/zod/v3/locales/en.js
 var errorMap = (issue2, _ctx) => {
   let message;
   switch (issue2.code) {
@@ -25029,13 +25029,13 @@ var errorMap = (issue2, _ctx) => {
 };
 var en_default = errorMap;
 
-// ../../../node_modules/zod/v3/errors.js
+// node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function getErrorMap() {
   return overrideErrorMap;
 }
 
-// ../../../node_modules/zod/v3/helpers/parseUtil.js
+// node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path, errorMaps, issueData } = params;
   const fullPath = [...path, ...issueData.path || []];
@@ -25144,14 +25144,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// ../../../node_modules/zod/v3/helpers/errorUtil.js
+// node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// ../../../node_modules/zod/v3/types.js
+// node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -28554,7 +28554,7 @@ var nullableType = ZodNullable.create;
 var preprocessType = ZodEffects.createWithPreprocess;
 var pipelineType = ZodPipeline.create;
 
-// ../../../node_modules/zod/v4/core/index.js
+// node_modules/zod/v4/core/index.js
 var core_exports2 = {};
 __export(core_exports2, {
   $ZodAny: () => $ZodAny,
@@ -28832,7 +28832,7 @@ __export(core_exports2, {
   version: () => version
 });
 
-// ../../../node_modules/zod/v4/core/core.js
+// node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
   status: "aborted"
 });
@@ -28907,7 +28907,7 @@ function config(newConfig) {
   return globalConfig;
 }
 
-// ../../../node_modules/zod/v4/core/util.js
+// node_modules/zod/v4/core/util.js
 var util_exports = {};
 __export(util_exports, {
   BIGINT_FORMAT_RANGES: () => BIGINT_FORMAT_RANGES,
@@ -29586,7 +29586,7 @@ var Class = class {
   }
 };
 
-// ../../../node_modules/zod/v4/core/errors.js
+// node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -29722,7 +29722,7 @@ function prettifyError(error48) {
   return lines.join("\n");
 }
 
-// ../../../node_modules/zod/v4/core/parse.js
+// node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -29810,7 +29810,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
 };
 var safeDecodeAsync = /* @__PURE__ */ _safeDecodeAsync($ZodRealError);
 
-// ../../../node_modules/zod/v4/core/regexes.js
+// node_modules/zod/v4/core/regexes.js
 var regexes_exports = {};
 __export(regexes_exports, {
   base64: () => base64,
@@ -29967,7 +29967,7 @@ var sha512_hex = /^[0-9a-fA-F]{128}$/;
 var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
 var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-// ../../../node_modules/zod/v4/core/checks.js
+// node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a2;
   inst._zod ?? (inst._zod = {});
@@ -30515,7 +30515,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// ../../../node_modules/zod/v4/core/doc.js
+// node_modules/zod/v4/core/doc.js
 var Doc = class {
   constructor(args = []) {
     this.content = [];
@@ -30551,14 +30551,14 @@ var Doc = class {
   }
 };
 
-// ../../../node_modules/zod/v4/core/versions.js
+// node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 3,
   patch: 6
 };
 
-// ../../../node_modules/zod/v4/core/schemas.js
+// node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a2;
   inst ?? (inst = {});
@@ -32529,7 +32529,7 @@ function handleRefineResult(result, payload, input, inst) {
   }
 }
 
-// ../../../node_modules/zod/v4/locales/index.js
+// node_modules/zod/v4/locales/index.js
 var locales_exports = {};
 __export(locales_exports, {
   ar: () => ar_default,
@@ -32583,7 +32583,7 @@ __export(locales_exports, {
   zhTW: () => zh_TW_default
 });
 
-// ../../../node_modules/zod/v4/locales/ar.js
+// node_modules/zod/v4/locales/ar.js
 var error = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0641", verb: "\u0623\u0646 \u064A\u062D\u0648\u064A" },
@@ -32690,7 +32690,7 @@ function ar_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/az.js
+// node_modules/zod/v4/locales/az.js
 var error2 = () => {
   const Sizable = {
     string: { unit: "simvol", verb: "olmal\u0131d\u0131r" },
@@ -32796,7 +32796,7 @@ function az_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/be.js
+// node_modules/zod/v4/locales/be.js
 function getBelarusianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
   const lastDigit = absCount % 10;
@@ -32953,7 +32953,7 @@ function be_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/bg.js
+// node_modules/zod/v4/locales/bg.js
 var error4 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0430", verb: "\u0434\u0430 \u0441\u044A\u0434\u044A\u0440\u0436\u0430" },
@@ -33074,7 +33074,7 @@ function bg_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ca.js
+// node_modules/zod/v4/locales/ca.js
 var error5 = () => {
   const Sizable = {
     string: { unit: "car\xE0cters", verb: "contenir" },
@@ -33183,7 +33183,7 @@ function ca_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/cs.js
+// node_modules/zod/v4/locales/cs.js
 var error6 = () => {
   const Sizable = {
     string: { unit: "znak\u016F", verb: "m\xEDt" },
@@ -33295,7 +33295,7 @@ function cs_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/da.js
+// node_modules/zod/v4/locales/da.js
 var error7 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "havde" },
@@ -33411,7 +33411,7 @@ function da_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/de.js
+// node_modules/zod/v4/locales/de.js
 var error8 = () => {
   const Sizable = {
     string: { unit: "Zeichen", verb: "zu haben" },
@@ -33520,7 +33520,7 @@ function de_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/en.js
+// node_modules/zod/v4/locales/en.js
 var error9 = () => {
   const Sizable = {
     string: { unit: "characters", verb: "to have" },
@@ -33629,7 +33629,7 @@ function en_default2() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/eo.js
+// node_modules/zod/v4/locales/eo.js
 var error10 = () => {
   const Sizable = {
     string: { unit: "karaktrojn", verb: "havi" },
@@ -33739,7 +33739,7 @@ function eo_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/es.js
+// node_modules/zod/v4/locales/es.js
 var error11 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
@@ -33872,7 +33872,7 @@ function es_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/fa.js
+// node_modules/zod/v4/locales/fa.js
 var error12 = () => {
   const Sizable = {
     string: { unit: "\u06A9\u0627\u0631\u0627\u06A9\u062A\u0631", verb: "\u062F\u0627\u0634\u062A\u0647 \u0628\u0627\u0634\u062F" },
@@ -33987,7 +33987,7 @@ function fa_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/fi.js
+// node_modules/zod/v4/locales/fi.js
 var error13 = () => {
   const Sizable = {
     string: { unit: "merkki\xE4", subject: "merkkijonon" },
@@ -34100,7 +34100,7 @@ function fi_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/fr.js
+// node_modules/zod/v4/locales/fr.js
 var error14 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
@@ -34209,7 +34209,7 @@ function fr_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/fr-CA.js
+// node_modules/zod/v4/locales/fr-CA.js
 var error15 = () => {
   const Sizable = {
     string: { unit: "caract\xE8res", verb: "avoir" },
@@ -34317,7 +34317,7 @@ function fr_CA_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/he.js
+// node_modules/zod/v4/locales/he.js
 var error16 = () => {
   const TypeNames = {
     string: { label: "\u05DE\u05D7\u05E8\u05D5\u05D6\u05EA", gender: "f" },
@@ -34512,7 +34512,7 @@ function he_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/hu.js
+// node_modules/zod/v4/locales/hu.js
 var error17 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
@@ -34621,7 +34621,7 @@ function hu_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/hy.js
+// node_modules/zod/v4/locales/hy.js
 function getArmenianPlural(count, one, many) {
   return Math.abs(count) === 1 ? one : many;
 }
@@ -34769,7 +34769,7 @@ function hy_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/id.js
+// node_modules/zod/v4/locales/id.js
 var error19 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
@@ -34876,7 +34876,7 @@ function id_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/is.js
+// node_modules/zod/v4/locales/is.js
 var error20 = () => {
   const Sizable = {
     string: { unit: "stafi", verb: "a\xF0 hafa" },
@@ -34986,7 +34986,7 @@ function is_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/it.js
+// node_modules/zod/v4/locales/it.js
 var error21 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
@@ -35095,7 +35095,7 @@ function it_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ja.js
+// node_modules/zod/v4/locales/ja.js
 var error22 = () => {
   const Sizable = {
     string: { unit: "\u6587\u5B57", verb: "\u3067\u3042\u308B" },
@@ -35203,7 +35203,7 @@ function ja_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ka.js
+// node_modules/zod/v4/locales/ka.js
 var error23 = () => {
   const Sizable = {
     string: { unit: "\u10E1\u10D8\u10DB\u10D1\u10DD\u10DA\u10DD", verb: "\u10E3\u10DC\u10D3\u10D0 \u10E8\u10D4\u10D8\u10EA\u10D0\u10D5\u10D3\u10D4\u10E1" },
@@ -35316,7 +35316,7 @@ function ka_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/km.js
+// node_modules/zod/v4/locales/km.js
 var error24 = () => {
   const Sizable = {
     string: { unit: "\u178F\u17BD\u17A2\u1780\u17D2\u179F\u179A", verb: "\u1782\u17BD\u179A\u1798\u17B6\u1793" },
@@ -35427,12 +35427,12 @@ function km_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/kh.js
+// node_modules/zod/v4/locales/kh.js
 function kh_default() {
   return km_default();
 }
 
-// ../../../node_modules/zod/v4/locales/ko.js
+// node_modules/zod/v4/locales/ko.js
 var error25 = () => {
   const Sizable = {
     string: { unit: "\uBB38\uC790", verb: "to have" },
@@ -35544,7 +35544,7 @@ function ko_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/lt.js
+// node_modules/zod/v4/locales/lt.js
 var capitalizeFirstCharacter = (text) => {
   return text.charAt(0).toUpperCase() + text.slice(1);
 };
@@ -35748,7 +35748,7 @@ function lt_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/mk.js
+// node_modules/zod/v4/locales/mk.js
 var error27 = () => {
   const Sizable = {
     string: { unit: "\u0437\u043D\u0430\u0446\u0438", verb: "\u0434\u0430 \u0438\u043C\u0430\u0430\u0442" },
@@ -35858,7 +35858,7 @@ function mk_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ms.js
+// node_modules/zod/v4/locales/ms.js
 var error28 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
@@ -35966,7 +35966,7 @@ function ms_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/nl.js
+// node_modules/zod/v4/locales/nl.js
 var error29 = () => {
   const Sizable = {
     string: { unit: "tekens", verb: "heeft" },
@@ -36077,7 +36077,7 @@ function nl_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/no.js
+// node_modules/zod/v4/locales/no.js
 var error30 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "\xE5 ha" },
@@ -36186,7 +36186,7 @@ function no_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ota.js
+// node_modules/zod/v4/locales/ota.js
 var error31 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmal\u0131d\u0131r" },
@@ -36296,7 +36296,7 @@ function ota_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ps.js
+// node_modules/zod/v4/locales/ps.js
 var error32 = () => {
   const Sizable = {
     string: { unit: "\u062A\u0648\u06A9\u064A", verb: "\u0648\u0644\u0631\u064A" },
@@ -36411,7 +36411,7 @@ function ps_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/pl.js
+// node_modules/zod/v4/locales/pl.js
 var error33 = () => {
   const Sizable = {
     string: { unit: "znak\xF3w", verb: "mie\u0107" },
@@ -36521,7 +36521,7 @@ function pl_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/pt.js
+// node_modules/zod/v4/locales/pt.js
 var error34 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
@@ -36630,7 +36630,7 @@ function pt_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ru.js
+// node_modules/zod/v4/locales/ru.js
 function getRussianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
   const lastDigit = absCount % 10;
@@ -36787,7 +36787,7 @@ function ru_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/sl.js
+// node_modules/zod/v4/locales/sl.js
 var error36 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
@@ -36897,7 +36897,7 @@ function sl_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/sv.js
+// node_modules/zod/v4/locales/sv.js
 var error37 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
@@ -37008,7 +37008,7 @@ function sv_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ta.js
+// node_modules/zod/v4/locales/ta.js
 var error38 = () => {
   const Sizable = {
     string: { unit: "\u0B8E\u0BB4\u0BC1\u0BA4\u0BCD\u0BA4\u0BC1\u0B95\u0BCD\u0B95\u0BB3\u0BCD", verb: "\u0B95\u0BCA\u0BA3\u0BCD\u0B9F\u0BBF\u0BB0\u0BC1\u0B95\u0BCD\u0B95 \u0BB5\u0BC7\u0BA3\u0BCD\u0B9F\u0BC1\u0BAE\u0BCD" },
@@ -37119,7 +37119,7 @@ function ta_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/th.js
+// node_modules/zod/v4/locales/th.js
 var error39 = () => {
   const Sizable = {
     string: { unit: "\u0E15\u0E31\u0E27\u0E2D\u0E31\u0E01\u0E29\u0E23", verb: "\u0E04\u0E27\u0E23\u0E21\u0E35" },
@@ -37230,7 +37230,7 @@ function th_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/tr.js
+// node_modules/zod/v4/locales/tr.js
 var error40 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "olmal\u0131" },
@@ -37336,7 +37336,7 @@ function tr_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/uk.js
+// node_modules/zod/v4/locales/uk.js
 var error41 = () => {
   const Sizable = {
     string: { unit: "\u0441\u0438\u043C\u0432\u043E\u043B\u0456\u0432", verb: "\u043C\u0430\u0442\u0438\u043C\u0435" },
@@ -37445,12 +37445,12 @@ function uk_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/ua.js
+// node_modules/zod/v4/locales/ua.js
 function ua_default() {
   return uk_default();
 }
 
-// ../../../node_modules/zod/v4/locales/ur.js
+// node_modules/zod/v4/locales/ur.js
 var error42 = () => {
   const Sizable = {
     string: { unit: "\u062D\u0631\u0648\u0641", verb: "\u06C1\u0648\u0646\u0627" },
@@ -37561,7 +37561,7 @@ function ur_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/uz.js
+// node_modules/zod/v4/locales/uz.js
 var error43 = () => {
   const Sizable = {
     string: { unit: "belgi", verb: "bo\u2018lishi kerak" },
@@ -37671,7 +37671,7 @@ function uz_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/vi.js
+// node_modules/zod/v4/locales/vi.js
 var error44 = () => {
   const Sizable = {
     string: { unit: "k\xFD t\u1EF1", verb: "c\xF3" },
@@ -37780,7 +37780,7 @@ function vi_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/zh-CN.js
+// node_modules/zod/v4/locales/zh-CN.js
 var error45 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u7B26", verb: "\u5305\u542B" },
@@ -37890,7 +37890,7 @@ function zh_CN_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/zh-TW.js
+// node_modules/zod/v4/locales/zh-TW.js
 var error46 = () => {
   const Sizable = {
     string: { unit: "\u5B57\u5143", verb: "\u64C1\u6709" },
@@ -37998,7 +37998,7 @@ function zh_TW_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/locales/yo.js
+// node_modules/zod/v4/locales/yo.js
 var error47 = () => {
   const Sizable = {
     string: { unit: "\xE0mi", verb: "n\xED" },
@@ -38106,7 +38106,7 @@ function yo_default() {
   };
 }
 
-// ../../../node_modules/zod/v4/core/registries.js
+// node_modules/zod/v4/core/registries.js
 var _a;
 var $output = /* @__PURE__ */ Symbol("ZodOutput");
 var $input = /* @__PURE__ */ Symbol("ZodInput");
@@ -38156,7 +38156,7 @@ function registry() {
 (_a = globalThis).__zod_globalRegistry ?? (_a.__zod_globalRegistry = registry());
 var globalRegistry = globalThis.__zod_globalRegistry;
 
-// ../../../node_modules/zod/v4/core/api.js
+// node_modules/zod/v4/core/api.js
 // @__NO_SIDE_EFFECTS__
 function _string(Class2, params) {
   return new Class2({
@@ -39195,7 +39195,7 @@ function _stringFormat(Class2, format, fnOrRegex, _params = {}) {
   return inst;
 }
 
-// ../../../node_modules/zod/v4/core/to-json-schema.js
+// node_modules/zod/v4/core/to-json-schema.js
 function initializeContext(params) {
   let target = params?.target ?? "draft-2020-12";
   if (target === "draft-4")
@@ -39547,7 +39547,7 @@ var createStandardJSONSchemaMethod = (schema, io, processors = {}) => (params) =
   return finalize(ctx, schema);
 };
 
-// ../../../node_modules/zod/v4/core/json-schema-processors.js
+// node_modules/zod/v4/core/json-schema-processors.js
 var formatMap = {
   guid: "uuid",
   url: "uri",
@@ -40098,7 +40098,7 @@ function toJSONSchema(input, params) {
   return finalize(ctx, input);
 }
 
-// ../../../node_modules/zod/v4/core/json-schema-generator.js
+// node_modules/zod/v4/core/json-schema-generator.js
 var JSONSchemaGenerator = class {
   /** @deprecated Access via ctx instead */
   get metadataRegistry() {
@@ -40173,10 +40173,10 @@ var JSONSchemaGenerator = class {
   }
 };
 
-// ../../../node_modules/zod/v4/core/json-schema.js
+// node_modules/zod/v4/core/json-schema.js
 var json_schema_exports = {};
 
-// ../../../node_modules/zod/v4/mini/schemas.js
+// node_modules/zod/v4/mini/schemas.js
 var ZodMiniType = /* @__PURE__ */ $constructor("ZodMiniType", (inst, def) => {
   if (!inst._zod)
     throw new Error("Uninitialized schema in ZodMiniType.");
@@ -40220,7 +40220,7 @@ function object(shape, params) {
   return new ZodMiniObject(def);
 }
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-compat.js
 function isZ4Schema(s) {
   const schema = s;
   return !!schema._zod;
@@ -40364,7 +40364,7 @@ function getLiteralValue(schema) {
   return void 0;
 }
 
-// ../../../node_modules/zod/v4/classic/external.js
+// node_modules/zod/v4/classic/external.js
 var external_exports3 = {};
 __export(external_exports3, {
   $brand: () => $brand,
@@ -40605,7 +40605,7 @@ __export(external_exports3, {
   xor: () => xor
 });
 
-// ../../../node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var schemas_exports3 = {};
 __export(schemas_exports3, {
   ZodAny: () => ZodAny2,
@@ -40774,7 +40774,7 @@ __export(schemas_exports3, {
   xor: () => xor
 });
 
-// ../../../node_modules/zod/v4/classic/checks.js
+// node_modules/zod/v4/classic/checks.js
 var checks_exports2 = {};
 __export(checks_exports2, {
   endsWith: () => _endsWith,
@@ -40808,7 +40808,7 @@ __export(checks_exports2, {
   uppercase: () => _uppercase
 });
 
-// ../../../node_modules/zod/v4/classic/iso.js
+// node_modules/zod/v4/classic/iso.js
 var iso_exports2 = {};
 __export(iso_exports2, {
   ZodISODate: () => ZodISODate,
@@ -40849,7 +40849,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// ../../../node_modules/zod/v4/classic/errors.js
+// node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -40889,7 +40889,7 @@ var ZodRealError = $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// ../../../node_modules/zod/v4/classic/parse.js
+// node_modules/zod/v4/classic/parse.js
 var parse2 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse3 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -40903,7 +40903,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// ../../../node_modules/zod/v4/classic/schemas.js
+// node_modules/zod/v4/classic/schemas.js
 var ZodType2 = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
   $ZodType.init(inst, def);
   Object.assign(inst["~standard"], {
@@ -41982,7 +41982,7 @@ function preprocess(fn, schema) {
   return pipe(transform(fn), schema);
 }
 
-// ../../../node_modules/zod/v4/classic/compat.js
+// node_modules/zod/v4/classic/compat.js
 var ZodIssueCode2 = {
   invalid_type: "invalid_type",
   too_big: "too_big",
@@ -42008,7 +42008,7 @@ var ZodFirstPartyTypeKind2;
 /* @__PURE__ */ (function(ZodFirstPartyTypeKind3) {
 })(ZodFirstPartyTypeKind2 || (ZodFirstPartyTypeKind2 = {}));
 
-// ../../../node_modules/zod/v4/classic/from-json-schema.js
+// node_modules/zod/v4/classic/from-json-schema.js
 var z = {
   ...schemas_exports3,
   ...checks_exports2,
@@ -42482,7 +42482,7 @@ function fromJSONSchema(schema, params) {
   return convertSchema(schema, ctx);
 }
 
-// ../../../node_modules/zod/v4/classic/coerce.js
+// node_modules/zod/v4/classic/coerce.js
 var coerce_exports2 = {};
 __export(coerce_exports2, {
   bigint: () => bigint3,
@@ -42507,10 +42507,10 @@ function date4(params) {
   return _coercedDate(ZodDate2, params);
 }
 
-// ../../../node_modules/zod/v4/classic/external.js
+// node_modules/zod/v4/classic/external.js
 config(en_default2());
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
 var LATEST_PROTOCOL_VERSION = "2025-11-25";
 var DEFAULT_NEGOTIATED_PROTOCOL_VERSION = "2025-03-26";
 var SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07"];
@@ -44030,12 +44030,12 @@ var UrlElicitationRequiredError = class extends McpError {
   }
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/interfaces.js
 function isTerminal(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/Options.js
+// node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = /* @__PURE__ */ Symbol("Let zodToJsonSchema decide on which parser to use");
 var defaultOptions = {
   name: void 0,
@@ -44069,7 +44069,7 @@ var getDefaultOptions = (options) => typeof options === "string" ? {
   ...options
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/Refs.js
+// node_modules/zod-to-json-schema/dist/esm/Refs.js
 var getRefs = (options) => {
   const _options = getDefaultOptions(options);
   const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
@@ -44090,7 +44090,7 @@ var getRefs = (options) => {
   };
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
 function addErrorMessage(res, key, errorMessage, refs) {
   if (!refs?.errorMessages)
     return;
@@ -44106,7 +44106,7 @@ function setResponseValueAndErrors(res, key, value, errorMessage, refs) {
   addErrorMessage(res, key, errorMessage, refs);
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
 var getRelativePath = (pathA, pathB) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
@@ -44116,7 +44116,7 @@ var getRelativePath = (pathA, pathB) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
 function parseAnyDef(refs) {
   if (refs.target !== "openAi") {
     return {};
@@ -44132,7 +44132,7 @@ function parseAnyDef(refs) {
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
 function parseArrayDef(def, refs) {
   const res = {
     type: "array"
@@ -44156,7 +44156,7 @@ function parseArrayDef(def, refs) {
   return res;
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
 function parseBigintDef(def, refs) {
   const res = {
     type: "integer",
@@ -44202,24 +44202,24 @@ function parseBigintDef(def, refs) {
   return res;
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
 function parseBooleanDef() {
   return {
     type: "boolean"
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
 function parseBrandedDef(_def, refs) {
   return parseDef(_def.type._def, refs);
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
 var parseCatchDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
 function parseDateDef(def, refs, overrideDateStrategy) {
   const strategy = overrideDateStrategy ?? refs.dateStrategy;
   if (Array.isArray(strategy)) {
@@ -44278,7 +44278,7 @@ var integerDateParser = (def, refs) => {
   return res;
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
 function parseDefaultDef(_def, refs) {
   return {
     ...parseDef(_def.innerType._def, refs),
@@ -44286,12 +44286,12 @@ function parseDefaultDef(_def, refs) {
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
 function parseEffectsDef(_def, refs) {
   return refs.effectStrategy === "input" ? parseDef(_def.schema._def, refs) : parseAnyDef(refs);
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
 function parseEnumDef(def) {
   return {
     type: "string",
@@ -44299,7 +44299,7 @@ function parseEnumDef(def) {
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
 var isJsonSchema7AllOfType = (type) => {
   if ("type" in type && type.type === "string")
     return false;
@@ -44341,7 +44341,7 @@ function parseIntersectionDef(def, refs) {
   } : void 0;
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
 function parseLiteralDef(def, refs) {
   const parsedType2 = typeof def.value;
   if (parsedType2 !== "bigint" && parsedType2 !== "number" && parsedType2 !== "boolean" && parsedType2 !== "string") {
@@ -44361,7 +44361,7 @@ function parseLiteralDef(def, refs) {
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var emojiRegex2 = void 0;
 var zodPatterns = {
   /**
@@ -44686,7 +44686,7 @@ function stringifyRegExpWithFlags(regex, refs) {
   return pattern;
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
 function parseRecordDef(def, refs) {
   if (refs.target === "openAi") {
     console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
@@ -44738,7 +44738,7 @@ function parseRecordDef(def, refs) {
   return schema;
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
 function parseMapDef(def, refs) {
   if (refs.mapStrategy === "record") {
     return parseRecordDef(def, refs);
@@ -44763,7 +44763,7 @@ function parseMapDef(def, refs) {
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
 function parseNativeEnumDef(def) {
   const object3 = def.values;
   const actualKeys = Object.keys(def.values).filter((key) => {
@@ -44777,7 +44777,7 @@ function parseNativeEnumDef(def) {
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
 function parseNeverDef(refs) {
   return refs.target === "openAi" ? void 0 : {
     not: parseAnyDef({
@@ -44787,7 +44787,7 @@ function parseNeverDef(refs) {
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
 function parseNullDef(refs) {
   return refs.target === "openApi3" ? {
     enum: ["null"],
@@ -44797,7 +44797,7 @@ function parseNullDef(refs) {
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
 var primitiveMappings = {
   ZodString: "string",
   ZodNumber: "number",
@@ -44865,7 +44865,7 @@ var asAnyOf = (def, refs) => {
   return anyOf.length ? { anyOf } : void 0;
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
 function parseNullableDef(def, refs) {
   if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
     if (refs.target === "openApi3") {
@@ -44897,7 +44897,7 @@ function parseNullableDef(def, refs) {
   return base && { anyOf: [base, { type: "null" }] };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
 function parseNumberDef(def, refs) {
   const res = {
     type: "number"
@@ -44946,7 +44946,7 @@ function parseNumberDef(def, refs) {
   return res;
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
 function parseObjectDef(def, refs) {
   const forceOptionalIntoNullable = refs.target === "openAi";
   const result = {
@@ -45016,7 +45016,7 @@ function safeIsOptional(schema) {
   }
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
 var parseOptionalDef = (def, refs) => {
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs);
@@ -45035,7 +45035,7 @@ var parseOptionalDef = (def, refs) => {
   } : parseAnyDef(refs);
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
 var parsePipelineDef = (def, refs) => {
   if (refs.pipeStrategy === "input") {
     return parseDef(def.in._def, refs);
@@ -45055,12 +45055,12 @@ var parsePipelineDef = (def, refs) => {
   };
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
 function parsePromiseDef(def, refs) {
   return parseDef(def.type._def, refs);
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
 function parseSetDef(def, refs) {
   const items = parseDef(def.valueType._def, {
     ...refs,
@@ -45080,7 +45080,7 @@ function parseSetDef(def, refs) {
   return schema;
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
 function parseTupleDef(def, refs) {
   if (def.rest) {
     return {
@@ -45108,24 +45108,24 @@ function parseTupleDef(def, refs) {
   }
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
 function parseUndefinedDef(refs) {
   return {
     not: parseAnyDef(refs)
   };
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
 function parseUnknownDef(refs) {
   return parseAnyDef(refs);
 }
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
 var parseReadonlyDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/selectParser.js
+// node_modules/zod-to-json-schema/dist/esm/selectParser.js
 var selectParser = (def, typeName, refs) => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
@@ -45201,7 +45201,7 @@ var selectParser = (def, typeName, refs) => {
   }
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/parseDef.js
+// node_modules/zod-to-json-schema/dist/esm/parseDef.js
 function parseDef(def, refs, forceResolution = false) {
   const seenItem = refs.seen.get(def);
   if (refs.override) {
@@ -45257,7 +45257,7 @@ var addMeta = (def, refs, jsonSchema) => {
   return jsonSchema;
 };
 
-// ../../../node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
 var zodToJsonSchema = (schema, options) => {
   const refs = getRefs(options);
   let definitions = typeof options === "object" && options.definitions ? Object.entries(options.definitions).reduce((acc, [name2, schema2]) => ({
@@ -45319,7 +45319,7 @@ var zodToJsonSchema = (schema, options) => {
   return combined;
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/zod-json-schema-compat.js
 function mapMiniTarget(t) {
   if (!t)
     return "draft-7";
@@ -45361,7 +45361,7 @@ function parseWithCompat(schema, data) {
   return result.data;
 }
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/protocol.js
 var DEFAULT_REQUEST_TIMEOUT_MSEC = 6e4;
 var Protocol = class {
   constructor(_options) {
@@ -46309,7 +46309,7 @@ function mergeCapabilities(base, additional) {
   return result;
 }
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
 var import_ajv = __toESM(require_ajv(), 1);
 var import_ajv_formats = __toESM(require_dist(), 1);
 function createDefaultAjvInstance() {
@@ -46377,7 +46377,7 @@ var AjvJsonSchemaValidator = class {
   }
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/server.js
 var ExperimentalServerTasks = class {
   constructor(_server) {
     this._server = _server;
@@ -46449,7 +46449,7 @@ var ExperimentalServerTasks = class {
   }
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/helpers.js
 function assertToolsCallTaskCapability(requests, method, entityName) {
   if (!requests) {
     throw new Error(`${entityName} does not support task creation (required for ${method})`);
@@ -46484,7 +46484,7 @@ function assertClientRequestTaskCapability(requests, method, entityName) {
   }
 }
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/index.js
 var Server = class extends Protocol {
   /**
    * Initializes this server with the given name and version information.
@@ -46864,7 +46864,7 @@ var Server = class extends Protocol {
   }
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/completable.js
 var COMPLETABLE_SYMBOL = /* @__PURE__ */ Symbol.for("mcp.completable");
 function isCompletable(schema) {
   return !!schema && typeof schema === "object" && COMPLETABLE_SYMBOL in schema;
@@ -46878,7 +46878,7 @@ var McpZodTypeKind;
   McpZodTypeKind2["Completable"] = "McpCompletable";
 })(McpZodTypeKind || (McpZodTypeKind = {}));
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/toolNameValidation.js
 var TOOL_NAME_REGEX = /^[A-Za-z0-9._-]{1,128}$/;
 function validateToolName(name) {
   const warnings = [];
@@ -46936,7 +46936,7 @@ function validateAndWarnToolName(name) {
   return result.isValid;
 }
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/mcp-server.js
 var ExperimentalMcpServerTasks = class {
   constructor(_mcpServer) {
     this._mcpServer = _mcpServer;
@@ -46951,7 +46951,7 @@ var ExperimentalMcpServerTasks = class {
   }
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js
 var McpServer = class {
   constructor(serverInfo, options) {
     this._registeredResources = {};
@@ -47737,10 +47737,10 @@ var EMPTY_COMPLETION_RESULT = {
   }
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 var import_node_process = __toESM(require("node:process"), 1);
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js
 var ReadBuffer = class {
   append(chunk) {
     this._buffer = this._buffer ? Buffer.concat([this._buffer, chunk]) : chunk;
@@ -47768,7 +47768,7 @@ function serializeMessage(message) {
   return JSON.stringify(message) + "\n";
 }
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/stdio.js
 var StdioServerTransport = class {
   constructor(_stdin = import_node_process.default.stdin, _stdout = import_node_process.default.stdout) {
     this._stdin = _stdin;
@@ -47829,7 +47829,7 @@ var StdioServerTransport = class {
   }
 };
 
-// ../../../node_modules/@hono/node-server/dist/index.mjs
+// node_modules/@hono/node-server/dist/index.mjs
 var import_http2 = require("http2");
 var import_http22 = require("http2");
 var import_stream = require("stream");
@@ -48361,7 +48361,7 @@ var getRequestListener = (fetchCallback, options = {}) => {
   };
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
 var WebStandardStreamableHTTPServerTransport = class {
   constructor(options = {}) {
     this._started = false;
@@ -48945,7 +48945,7 @@ data:
   }
 };
 
-// ../../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js
+// node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js
 var StreamableHTTPServerTransport = class {
   constructor(options = {}) {
     this._requestContext = /* @__PURE__ */ new WeakMap();
@@ -49047,7 +49047,7 @@ var StreamableHTTPServerTransport = class {
   }
 };
 
-// ../../../node_modules/ws/wrapper.mjs
+// node_modules/ws/wrapper.mjs
 var import_stream2 = __toESM(require_stream(), 1);
 var import_receiver = __toESM(require_receiver(), 1);
 var import_sender = __toESM(require_sender(), 1);
@@ -49159,10 +49159,9 @@ function substituteManifestPort(content, defaultPort, targetPort) {
 }
 
 // server/tools.ts
-var import_node_fs = require("node:fs");
+var import_node_fs2 = require("node:fs");
 var import_node_os = require("node:os");
-var import_node_path = require("node:path");
-var import_xmldom2 = __toESM(require_lib(), 1);
+var import_node_path2 = require("node:path");
 
 // server/chart-builder.ts
 var C_NS = "http://schemas.openxmlformats.org/drawingml/2006/chart";
@@ -49350,6 +49349,184 @@ function resolveChartPosition(pos) {
   };
 }
 
+// server/icons.ts
+var import_node_fs = require("node:fs");
+var import_node_path = require("node:path");
+var import_node_url = require("node:url");
+var import_meta = {};
+var MANIFEST_URL = "https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/fonts/FluentSystemIcons-Regular.json";
+var CDN_BASE = "https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets";
+var DEFAULT_SIZE = 24;
+var cachedIndex = null;
+var svgCache = /* @__PURE__ */ new Map();
+function snakeToTitle(s) {
+  return s.split("_").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+}
+function titleToSnake(s) {
+  return s.replace(/\s+/g, "_").toLowerCase();
+}
+function nameToId(name, mono) {
+  const base = `Icons_${name.replace(/\s+/g, "_")}`;
+  return mono ? `${base}_M` : base;
+}
+function parseIconId(iconId) {
+  let id = iconId;
+  let isMono = false;
+  if (id.endsWith("_M")) {
+    isMono = true;
+    id = id.slice(0, -2);
+  }
+  if (id.startsWith("Icons_")) {
+    id = id.slice(6);
+  }
+  return { snakeName: id.toLowerCase(), isMono };
+}
+function buildIndexFromManifest(manifest) {
+  const seen = /* @__PURE__ */ new Set();
+  const entries = [];
+  for (const key of Object.keys(manifest)) {
+    const match = key.match(/^ic_fluent_(.+)_(\d+)_regular$/);
+    if (!match) continue;
+    const snakeName = match[1];
+    if (seen.has(snakeName)) continue;
+    seen.add(snakeName);
+    const name = snakeToTitle(snakeName);
+    entries.push({
+      name,
+      snakeName,
+      keywords: snakeName.split("_")
+    });
+  }
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+function loadStaticIndex() {
+  try {
+    const dir = (0, import_node_path.dirname)((0, import_node_url.fileURLToPath)(import_meta.url));
+    const raw = (0, import_node_fs.readFileSync)((0, import_node_path.join)(dir, "icon-index.json"), "utf-8");
+    const data = JSON.parse(raw);
+    return data.map((e) => ({
+      name: e.n,
+      snakeName: titleToSnake(e.n),
+      keywords: e.k.split(" ")
+    }));
+  } catch {
+    return null;
+  }
+}
+async function loadIndex() {
+  if (cachedIndex) return cachedIndex;
+  const staticIndex = loadStaticIndex();
+  if (staticIndex && staticIndex.length > 0) {
+    cachedIndex = staticIndex;
+    return cachedIndex;
+  }
+  const resp = await fetch(MANIFEST_URL);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch icon manifest: ${resp.status} ${resp.statusText}`);
+  }
+  const manifest = await resp.json();
+  cachedIndex = buildIndexFromManifest(manifest);
+  return cachedIndex;
+}
+function scoreMatch(entry, queryWords) {
+  let score = 0;
+  const nameLower = entry.name.toLowerCase();
+  const allWords = [nameLower, ...entry.keywords];
+  for (const qw of queryWords) {
+    if (entry.keywords.includes(qw)) {
+      score += 10;
+      continue;
+    }
+    if (nameLower.includes(qw)) {
+      score += 8;
+      continue;
+    }
+    if (entry.keywords.some((kw) => kw.startsWith(qw))) {
+      score += 5;
+      continue;
+    }
+    if (allWords.some((w) => w.includes(qw))) {
+      score += 3;
+      continue;
+    }
+    score -= 2;
+  }
+  const queryJoined = queryWords.join(" ");
+  if (nameLower === queryJoined) {
+    score += 20;
+  }
+  return score;
+}
+async function searchIcons(query, top = 10, style) {
+  const index = await loadIndex();
+  const queryWords = query.toLowerCase().split(/\s+/).filter((w) => w.length > 0);
+  if (queryWords.length === 0) return [];
+  const scored = index.map((entry) => ({ entry, score: scoreMatch(entry, queryWords) })).filter((x) => x.score > 0).sort((a, b) => b.score - a.score).slice(0, top);
+  const isMono = style === "regular";
+  const isFilled = style === "filled";
+  if (!isMono && !isFilled) {
+    const results = [];
+    for (const { entry, score } of scored) {
+      results.push({
+        id: nameToId(entry.name, true),
+        description: `${entry.name} (mono/outline)`,
+        isMono: true,
+        contentTier: "free",
+        searchScore: score
+      });
+      results.push({
+        id: nameToId(entry.name, false),
+        description: `${entry.name} (filled)`,
+        isMono: false,
+        contentTier: "free",
+        searchScore: score
+      });
+    }
+    return results.slice(0, top);
+  }
+  return scored.map(({ entry, score }) => ({
+    id: nameToId(entry.name, isMono),
+    description: `${entry.name} (${isMono ? "mono/outline" : "filled"})`,
+    isMono,
+    contentTier: "free",
+    searchScore: score
+  }));
+}
+function buildSvgUrl(snakeName, isMono) {
+  const dirName = snakeToTitle(snakeName);
+  const style = isMono ? "regular" : "filled";
+  const fileName = `ic_fluent_${snakeName}_${DEFAULT_SIZE}_${style}.svg`;
+  return `${CDN_BASE}/${encodeURIComponent(dirName)}/SVG/${fileName}`;
+}
+function recolorSvg(svg, color) {
+  const styleTag = `<style>.icon-color{fill:${color}}</style>`;
+  let result = svg.replace(/(<svg[^>]*>)/, `$1${styleTag}`);
+  result = result.replace(/(<(?:path|circle|rect|polygon|ellipse)[^>]*?)fill="[^"]*"/g, '$1class="icon-color"');
+  result = result.replace(
+    /(<(?:path|circle|rect|polygon|ellipse)(?![^>]*class=)[^>]*?)(\/?>)/g,
+    '$1 class="icon-color"$2'
+  );
+  return result;
+}
+async function fetchIconSvg(iconId, color) {
+  const { snakeName, isMono } = parseIconId(iconId);
+  const cacheKey2 = `${snakeName}:${isMono ? "regular" : "filled"}`;
+  let svg = svgCache.get(cacheKey2);
+  if (!svg) {
+    const url2 = buildSvgUrl(snakeName, isMono);
+    const resp = await fetch(url2);
+    if (!resp.ok) {
+      throw new Error(`Failed to fetch icon SVG: ${resp.status} ${resp.statusText} (${url2})`);
+    }
+    svg = await resp.text();
+    svgCache.set(cacheKey2, svg);
+  }
+  if (color) {
+    svg = recolorSvg(svg, color);
+  }
+  return Buffer.from(svg).toString("base64");
+}
+
 // server/xml-helpers.ts
 var import_xmldom = __toESM(require_lib(), 1);
 var import_jszip = __toESM(require_lib4(), 1);
@@ -49380,7 +49557,6 @@ async function reimportSlide(pool2, modifiedBase64, slideId, prevSlideId, target
     var slides = context.presentation.slides;
     slides.load("items");
     await context.sync();
-    var countBefore = slides.items.length;
     // Find and delete the original slide by ID
     var found = false;
     for (var i = 0; i < slides.items.length; i++) {
@@ -49393,24 +49569,16 @@ async function reimportSlide(pool2, modifiedBase64, slideId, prevSlideId, target
     if (!found) {
       throw new Error("Original slide not found for reimport (ID: ${slideId})");
     }
-    // Batch delete + insert in one sync to reduce the window for partial failure
+    await context.sync();
+    // Insert modified slide at the correct position
     context.presentation.insertSlidesFromBase64("${modifiedBase64}", ${optionsStr});
     await context.sync();
-    // Verify slide count is unchanged (deleted one, inserted one)
-    slides.load("items");
-    await context.sync();
-    if (slides.items.length !== countBefore) {
-      throw new Error("Reimport verification failed: expected " + countBefore + " slides but found " + slides.items.length);
-    }
     return { success: true };
   `;
   await pool2.sendCommand("executeCode", { code }, targetWs, timeout);
 }
 var NS_P = "http://schemas.openxmlformats.org/presentationml/2006/main";
 var NS_A = "http://schemas.openxmlformats.org/drawingml/2006/main";
-function escapeXml(text) {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
-}
 function parseSlideXml(xmlString) {
   return new import_xmldom.DOMParser().parseFromString(xmlString, "text/xml");
 }
@@ -49603,107 +49771,32 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
     }
   );
   server.tool(
-    "list_slides",
-    "Lightweight deck index (~5 tokens/slide): returns slide dimensions (slideWidth, slideHeight) and all slides with index, ID, and shape count. Use as the first call to understand deck structure. For shape details, follow up with scan_slide or inspect_slide on specific slides.",
+    "get_presentation",
+    "Returns the structure of the currently open PowerPoint presentation including all slides with their IDs and shape summaries (count, names, types). Use this first to understand what's in the presentation before making changes.",
     {
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
     async ({ presentationId }) => {
       try {
         const code = `
-          var p = context.presentation;
-          var slides = p.slides;
-          var ps = p.pageSetup;
+          var slides = context.presentation.slides;
           slides.load("items");
-          ps.load("slideWidth,slideHeight");
+          await context.sync();
+          for (var i = 0; i < slides.items.length; i++) {
+            slides.items[i].shapes.load("items");
+          }
           await context.sync();
           var output = [];
           for (var i = 0; i < slides.items.length; i++) {
             var slide = slides.items[i];
-            slide.shapes.load("items");
-          }
-          await context.sync();
-          for (var i = 0; i < slides.items.length; i++) {
-            var slide = slides.items[i];
-            output.push({ index: i, id: slide.id, shapeCount: slide.shapes.items.length });
-          }
-          return { slideWidth: ps.slideWidth, slideHeight: ps.slideHeight, slides: output };
-        `;
-        const target = pool2.resolveTarget(presentationId);
-        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
-        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
-        const text = JSON.stringify(result, null, 2) + (warning ?? "");
-        return { content: [{ type: "text", text }] };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
-      }
-    }
-  );
-  server.tool(
-    "inspect_slide",
-    "Detailed slide inspector (~80 tokens/shape): returns every shape with text content, positions, sizes, and fill colors, plus slide dimensions. Supports slideRange for multiple slides. For just positions without text/fills, use scan_slide instead.",
-    {
-      slideRange: external_exports3.string().describe('Slide indices to inspect, e.g. "0", "0-5", "2,4,7". Single index or range.'),
-      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
-    },
-    async ({ slideRange, presentationId }) => {
-      try {
-        const indices = parseSlideRange(slideRange) ?? [];
-        if (indices.length === 0) throw new Error("slideRange is required");
-        const indicesJs = JSON.stringify(indices);
-        const code = `
-          var p = context.presentation;
-          var slides = p.slides;
-          var ps = p.pageSetup;
-          slides.load("items");
-          ps.load("slideWidth,slideHeight");
-          await context.sync();
-          var requestedIndices = ${indicesJs};
-          for (var i = 0; i < requestedIndices.length; i++) {
-            if (requestedIndices[i] >= slides.items.length) {
-              throw new Error("Slide index " + requestedIndices[i] + " out of range (presentation has " + slides.items.length + " slides)");
-            }
-          }
-          for (var i = 0; i < requestedIndices.length; i++) {
-            slides.items[requestedIndices[i]].shapes.load("items");
-          }
-          await context.sync();
-          var output = [];
-          for (var i = 0; i < requestedIndices.length; i++) {
-            var idx = requestedIndices[i];
-            var slide = slides.items[idx];
             var shapes = [];
             for (var j = 0; j < slide.shapes.items.length; j++) {
               var s = slide.shapes.items[j];
-              var info = {
-                name: s.name,
-                type: s.type,
-                id: s.id,
-                left: s.left,
-                top: s.top,
-                width: s.width,
-                height: s.height
-              };
-              try {
-                s.textFrame.load("textRange");
-                await context.sync();
-                info.text = s.textFrame.textRange.text;
-              } catch (e) {
-                // Shape has no text frame (e.g., images, connectors)
-              }
-              try {
-                s.fill.load("foregroundColor,type");
-                await context.sync();
-                info.fill = { type: s.fill.type, color: s.fill.foregroundColor };
-              } catch (e) {
-                // Shape has no fill or fill not accessible
-              }
-              shapes.push(info);
+              shapes.push({ name: s.name, type: s.type, id: s.id });
             }
-            output.push({ slideIndex: idx, slideId: slide.id, shapes: shapes });
+            output.push({ index: i, id: slide.id, shapeCount: shapes.length, shapes: shapes });
           }
-          return { slideWidth: ps.slideWidth, slideHeight: ps.slideHeight, slides: output };
+          return output;
         `;
         const target = pool2.resolveTarget(presentationId);
         const result = await pool2.sendCommand("executeCode", { code }, target.ws);
@@ -49717,54 +49810,53 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
     }
   );
   server.tool(
-    "scan_slide",
-    "Lightweight shape scanner (~40 tokens/shape): lists shape IDs, types, and positions on slides, plus slide dimensions. Supports slideRange for multiple slides. For text content and fills, use inspect_slide instead.",
+    "get_slide",
+    "Returns detailed information about all shapes on a specific slide, including text content, positions (left, top in points), sizes (width, height in points), and fill colors. Use slideIndex from get_presentation results (zero-based).",
     {
-      slideRange: external_exports3.string().describe('Slide indices to scan, e.g. "0", "0-5", "2,4,7". Single index or range.'),
+      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
-    async ({ slideRange, presentationId }) => {
+    async ({ slideIndex, presentationId }) => {
       try {
-        const indices = parseSlideRange(slideRange) ?? [];
-        if (indices.length === 0) throw new Error("slideRange is required");
-        const indicesJs = JSON.stringify(indices);
         const code = `
-          var p = context.presentation;
-          var slides = p.slides;
-          var ps = p.pageSetup;
+          var slides = context.presentation.slides;
           slides.load("items");
-          ps.load("slideWidth,slideHeight");
           await context.sync();
-          var requestedIndices = ${indicesJs};
-          for (var i = 0; i < requestedIndices.length; i++) {
-            if (requestedIndices[i] >= slides.items.length) {
-              throw new Error("Slide index " + requestedIndices[i] + " out of range (presentation has " + slides.items.length + " slides)");
-            }
+          if (${slideIndex} >= slides.items.length) {
+            throw new Error("Slide index " + ${slideIndex} + " out of range (presentation has " + slides.items.length + " slides)");
           }
-          for (var i = 0; i < requestedIndices.length; i++) {
-            slides.items[requestedIndices[i]].shapes.load("items");
-          }
+          var slide = slides.items[${slideIndex}];
+          slide.shapes.load("items");
           await context.sync();
-          var output = [];
-          for (var i = 0; i < requestedIndices.length; i++) {
-            var idx = requestedIndices[i];
-            var slide = slides.items[idx];
-            var shapes = [];
-            for (var j = 0; j < slide.shapes.items.length; j++) {
-              var s = slide.shapes.items[j];
-              shapes.push({
-                id: s.id,
-                name: s.name,
-                type: s.type,
-                left: s.left,
-                top: s.top,
-                width: s.width,
-                height: s.height
-              });
+          var shapes = [];
+          for (var i = 0; i < slide.shapes.items.length; i++) {
+            var s = slide.shapes.items[i];
+            var info = {
+              name: s.name,
+              type: s.type,
+              id: s.id,
+              left: s.left,
+              top: s.top,
+              width: s.width,
+              height: s.height
+            };
+            try {
+              s.textFrame.load("textRange");
+              await context.sync();
+              info.text = s.textFrame.textRange.text;
+            } catch (e) {
+              // Shape has no text frame (e.g., images, connectors)
             }
-            output.push({ slideIndex: idx, slideId: slide.id, shapes: shapes });
+            try {
+              s.fill.load("foregroundColor,type");
+              await context.sync();
+              info.fill = { type: s.fill.type, color: s.fill.foregroundColor };
+            } catch (e) {
+              // Shape has no fill or fill not accessible
+            }
+            shapes.push(info);
           }
-          return { slideWidth: ps.slideWidth, slideHeight: ps.slideHeight, slides: output };
+          return { slideIndex: ${slideIndex}, slideId: slide.id, shapes: shapes };
         `;
         const target = pool2.resolveTarget(presentationId);
         const result = await pool2.sendCommand("executeCode", { code }, target.ws);
@@ -49778,10 +49870,10 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
     }
   );
   server.tool(
-    "screenshot_slide",
-    "Slide screenshot (~1000 tokens): captures one slide as PNG image. Use to visually verify layout after changes. Do NOT loop over all slides \u2014 use preview_deck instead.",
+    "get_slide_image",
+    "Captures a visual screenshot of a specific slide as a PNG image. Use this to SEE what a slide looks like \u2014 useful for verifying layout after changes or understanding content visually. Requires PowerPoint 16.96+ (PowerPointApi 1.8).",
     {
-      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from list_slides results"),
+      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
       width: external_exports3.number().int().min(1).max(4096).optional().describe(
         "Image width in pixels. Default: 720. Height auto-calculated to preserve aspect ratio unless also specified."
       ),
@@ -49915,7 +50007,7 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
       try {
         let base64Data;
         if (sourceType === "file") {
-          base64Data = (0, import_node_fs.readFileSync)(source).toString("base64");
+          base64Data = (0, import_node_fs2.readFileSync)(source).toString("base64");
         } else if (sourceType === "url") {
           const resp = await fetch(source);
           if (!resp.ok) {
@@ -49967,8 +50059,8 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
     }
   );
   server.tool(
-    "preview_deck",
-    "Deck preview: batch overview of all/selected slides with optional thumbnails + text. With images: ~900 tokens/slide; text-only (includeImages=false): ~35 tokens/slide. Use for visual review or content audit. Do NOT use to inspect one slide \u2014 use inspect_slide or screenshot_slide instead.",
+    "get_deck_overview",
+    "Returns a visual overview of all (or selected) slides in one call \u2014 thumbnails interleaved with text metadata. Much more efficient than calling get_slide + get_slide_image per slide. Use this to review or audit an entire presentation quickly.",
     {
       slideRange: external_exports3.string().optional().describe('Slide indices to include, e.g. "0-5", "2,4,7", "0-2,5,8-10". Omit for all slides.'),
       imageWidth: external_exports3.number().int().min(120).max(1920).optional().describe("Thumbnail width in pixels. Default: 480. Height auto-calculated to preserve aspect ratio."),
@@ -49982,11 +50074,8 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
         const withImages = includeImages !== false;
         const indicesJs = indices ? JSON.stringify(indices) : "null";
         const code = `
-          var p = context.presentation;
-          var slides = p.slides;
-          var ps = p.pageSetup;
+          var slides = context.presentation.slides;
           slides.load("items");
-          ps.load("slideWidth,slideHeight");
           await context.sync();
           var requestedIndices = ${indicesJs};
           var indicesToProcess = requestedIndices || [];
@@ -50025,14 +50114,14 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
             slideData.imageBase64 = img.value;` : ""}
             output.push(slideData);
           }
-          return { slideCount: slides.items.length, slideWidth: ps.slideWidth, slideHeight: ps.slideHeight, slides: output };
+          return { slideCount: slides.items.length, slides: output };
         `;
         const target = pool2.resolveTarget(presentationId);
         const result = await pool2.sendCommand("executeCode", { code }, target.ws, 12e4);
         const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
         const content = [];
         const showing = result.slides.length;
-        const header = `Deck overview: ${result.slideCount} total slides (${result.slideWidth} x ${result.slideHeight} pt), showing ${showing}${warning ?? ""}`;
+        const header = `Deck overview: ${result.slideCount} total slides, showing ${showing}${warning ?? ""}`;
         content.push({ type: "text", text: header });
         for (const slide of result.slides) {
           if (slide.imageBase64) {
@@ -50064,7 +50153,7 @@ ${textParts.join("\n")}` : "\n(no text content)";
         const target = pool2.resolveTarget(presentationId);
         const filePath = target.filePath;
         if (filePath && !filePath.startsWith("http")) {
-          if (!(0, import_node_fs.existsSync)(filePath)) {
+          if (!(0, import_node_fs2.existsSync)(filePath)) {
             return {
               content: [{ type: "text", text: `Error: Local file not found: ${filePath}` }],
               isError: true
@@ -50082,7 +50171,7 @@ ${textParts.join("\n")}` : "\n(no text content)";
         `;
         const currentRevision = await pool2.sendCommand("executeCode", { code: revCode }, target.ws);
         const cached2 = localCopyCache.get(target.presentationId);
-        if (cached2 && cached2.revision === currentRevision && (0, import_node_fs.existsSync)(cached2.localPath)) {
+        if (cached2 && cached2.revision === currentRevision && (0, import_node_fs2.existsSync)(cached2.localPath)) {
           return {
             content: [
               {
@@ -50138,8 +50227,8 @@ ${textParts.join("\n")}` : "\n(no text content)";
         `;
         const base643 = await pool2.sendCommand("executeCode", { code: exportCode }, target.ws, 12e4);
         const filename = filePath ? decodeURIComponent(filePath.split("/").pop() || "presentation.pptx") : "presentation.pptx";
-        const dest = (0, import_node_path.join)((0, import_node_os.tmpdir)(), `pptbridge-${Date.now()}-${filename}`);
-        (0, import_node_fs.writeFileSync)(dest, Buffer.from(base643, "base64"));
+        const dest = (0, import_node_path2.join)((0, import_node_os.tmpdir)(), `pptbridge-${Date.now()}-${filename}`);
+        (0, import_node_fs2.writeFileSync)(dest, Buffer.from(base643, "base64"));
         localCopyCache.set(target.presentationId, { localPath: dest, revision: currentRevision });
         return {
           content: [
@@ -50159,8 +50248,8 @@ ${textParts.join("\n")}` : "\n(no text content)";
     "read_slide_text",
     "Read raw OOXML <a:p> paragraphs from a shape's text body. Returns the paragraph XML as a string \u2014 preserves all formatting (bold, colors, bullets, etc.) that textRange.text strips. Use with the /pptx skill's OOXML knowledge to understand and modify the XML.",
     {
-      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from list_slides results"),
-      shapeId: external_exports3.string().describe('Shape ID from inspect_slide results (e.g. "5")'),
+      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
+      shapeId: external_exports3.string().describe('Shape ID from get_slide results (e.g. "5")'),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
     async ({ slideIndex, shapeId, presentationId }) => {
@@ -50186,7 +50275,7 @@ ${textParts.join("\n")}` : "\n(no text content)";
     "Replace paragraph content of a shape with raw OOXML <a:p> XML. Preserves <a:bodyPr> and <a:lstStyle>. Use read_slide_text first to get the current XML, modify it (using /pptx skill knowledge), then write it back. The slide is exported, modified server-side, and reimported \u2014 data never enters Claude's context.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
-      shapeId: external_exports3.string().describe("Shape ID from inspect_slide results"),
+      shapeId: external_exports3.string().describe("Shape ID from get_slide results"),
       xml: external_exports3.string().describe("The <a:p> paragraph XML to replace the current text body content with"),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
@@ -50216,7 +50305,7 @@ ${textParts.join("\n")}` : "\n(no text content)";
     "read_slide_xml",
     "Read the full raw OOXML of a slide, or filter to a specific shape. Returns the slide's ppt/slides/slide1.xml content. Use with the /pptx skill's OOXML knowledge to understand the XML structure.",
     {
-      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from list_slides results"),
+      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
       shapeId: external_exports3.string().optional().describe("Optional shape ID to filter to. If provided, returns only that shape's <p:sp> element."),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
@@ -50242,57 +50331,22 @@ ${textParts.join("\n")}` : "\n(no text content)";
   );
   server.tool(
     "edit_slide_xml",
-    "Edit slide XML and reimport. Two modes: (1) xml mode \u2014 provide finished XML string (use read_slide_xml first to get current XML), (2) code mode \u2014 provide JS code that manipulates the pre-parsed DOM (receives: doc, findShapeById, NS_P, NS_A, escapeXml, serializeXml, DOMParser). Code mode preserves untouched attributes. The slide is exported, modified server-side, and reimported \u2014 data never enters Claude's context.",
+    "Replace the full slide XML or a specific shape's XML and reimport. Use read_slide_xml first to get the current XML, modify it, then write it back. The slide is exported, modified server-side, and reimported \u2014 data never enters Claude's context.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
-      xml: external_exports3.string().optional().describe(
-        "Modified XML \u2014 full slide XML or a single shape's <p:sp> element (when shapeId is provided). Mutually exclusive with 'code'."
-      ),
-      code: external_exports3.string().optional().describe(
-        "JS code that manipulates the pre-parsed slide DOM. Receives: doc (Document), findShapeById(id) \u2192 Element|null, NS_P, NS_A (namespace strings), escapeXml(text), serializeXml(node), DOMParser. Mutually exclusive with 'xml'."
-      ),
-      explanation: external_exports3.string().optional().describe("Brief description of what the code does (for logging, max 50 chars). Only used with code mode."),
+      xml: external_exports3.string().describe("Modified XML \u2014 full slide XML or a single shape's <p:sp> element (when shapeId is provided)"),
       shapeId: external_exports3.string().optional().describe(
-        "Optional shape ID (xml mode only). If provided, replaces only that shape's <p:sp> element instead of the full slide XML."
+        "Optional shape ID. If provided, replaces only that shape's <p:sp> element instead of the full slide XML."
       ),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
-    async ({ slideIndex, xml, code, shapeId, presentationId }) => {
-      if (!xml && !code || xml && code) {
-        return {
-          content: [
-            { type: "text", text: "Error: Provide either 'xml' or 'code', not both and not neither." }
-          ],
-          isError: true
-        };
-      }
+    async ({ slideIndex, xml, shapeId, presentationId }) => {
       try {
         const target = pool2.resolveTarget(presentationId);
         const exported = await exportSlide(pool2, slideIndex, target.ws);
         const { zip, xmlString } = await extractSlideXmlFromZip(exported.base64);
         let finalXml;
-        if (code) {
-          const doc = parseSlideXml(xmlString);
-          const sandbox = {
-            doc,
-            findShapeById: (id) => findShapeById(doc, id),
-            NS_P,
-            NS_A,
-            escapeXml,
-            serializeXml: (node) => serializeXml(node),
-            DOMParser: import_xmldom2.DOMParser
-          };
-          try {
-            const keys = Object.keys(sandbox);
-            const values = Object.values(sandbox);
-            const fn = new Function(...keys, code);
-            fn(...values);
-          } catch (codeErr) {
-            const msg = codeErr instanceof Error ? codeErr.message : String(codeErr);
-            throw new Error(`Code execution error: ${msg}`);
-          }
-          finalXml = serializeXml(doc);
-        } else if (shapeId) {
+        if (shapeId) {
           const doc = parseSlideXml(xmlString);
           const shape = findShapeById(doc, shapeId);
           if (!shape) {
@@ -50363,16 +50417,16 @@ ${textParts.join("\n")}` : "\n(no text content)";
   );
   server.tool(
     "verify_slides",
-    "Run programmatic checks on a slide: detect overlapping shapes, out-of-bounds shapes, empty text, tiny shapes, and unused placeholders. Returns a list of issues found. Uses the same shape data as inspect_slide \u2014 no OOXML needed.",
+    "Run programmatic checks on a slide: detect overlapping shapes, out-of-bounds shapes, empty text, and tiny shapes. Returns a list of issues found. Uses the same shape data as get_slide \u2014 no OOXML needed.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
-      checks: external_exports3.array(external_exports3.enum(["overlap", "bounds", "empty_text", "tiny_shapes", "unused_placeholder"])).optional().describe("Checks to run. Default: all five checks."),
+      checks: external_exports3.array(external_exports3.enum(["overlap", "bounds", "empty_text", "tiny_shapes"])).optional().describe("Checks to run. Default: all four checks."),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
     async ({ slideIndex, checks, presentationId }) => {
       try {
         const target = pool2.resolveTarget(presentationId);
-        const enabledChecks = checks ?? ["overlap", "bounds", "empty_text", "tiny_shapes", "unused_placeholder"];
+        const enabledChecks = checks ?? ["overlap", "bounds", "empty_text", "tiny_shapes"];
         const code = `
           var slides = context.presentation.slides;
           slides.load("items");
@@ -50395,27 +50449,17 @@ ${textParts.join("\n")}` : "\n(no text content)";
               height: s.height
             };
             try {
-              var tf = s.getTextFrameOrNullObject();
-              tf.load(["hasText", "textRange"]);
+              s.textFrame.load("textRange");
               await context.sync();
-              if (!tf.isNullObject) {
-                info.text = tf.hasText ? tf.textRange.text : "";
-                info.hasText = tf.hasText;
-              }
-            } catch (e) {}
-            try {
-              var pf = s.getPlaceholderOrNullObject();
-              pf.load("type");
-              await context.sync();
-              if (!pf.isNullObject) info.isPlaceholder = true;
+              info.text = s.textFrame.textRange.text;
             } catch (e) {}
             shapes.push(info);
           }
           // Also get slide dimensions
-          var ps = context.presentation.pageSetup;
-          ps.load("slideWidth,slideHeight");
+          var p = context.presentation;
+          p.load("slideWidth,slideHeight");
           await context.sync();
-          return { shapes: shapes, slideWidth: ps.slideWidth, slideHeight: ps.slideHeight };
+          return { shapes: shapes, slideWidth: p.slideWidth, slideHeight: p.slideHeight };
         `;
         const slideData = await pool2.sendCommand("executeCode", { code }, target.ws);
         const issues = [];
@@ -50427,10 +50471,10 @@ ${textParts.join("\n")}` : "\n(no text content)";
               const b = shapes[j];
               if (a.left < b.left + b.width && a.left + a.width > b.left && a.top < b.top + b.height && a.top + a.height > b.top) {
                 issues.push({
-                  type: "overlap",
+                  check: "overlap",
                   severity: "warning",
-                  shapeIds: [a.id, b.id],
-                  description: `"${a.name}" and "${b.name}" overlap`
+                  shapes: [a.name, b.name],
+                  message: `"${a.name}" and "${b.name}" overlap`
                 });
               }
             }
@@ -50445,10 +50489,10 @@ ${textParts.join("\n")}` : "\n(no text content)";
             if (s.top + s.height > slideHeight) outOfBounds.push("below slide");
             if (outOfBounds.length > 0) {
               issues.push({
-                type: "bounds",
+                check: "bounds",
                 severity: "warning",
-                shapeIds: [s.id],
-                description: `"${s.name}" extends ${outOfBounds.join(", ")}`
+                shapes: [s.name],
+                message: `"${s.name}" extends ${outOfBounds.join(", ")}`
               });
             }
           }
@@ -50457,10 +50501,10 @@ ${textParts.join("\n")}` : "\n(no text content)";
           for (const s of shapes) {
             if (s.text !== void 0 && s.text.trim() === "") {
               issues.push({
-                type: "empty_text",
+                check: "empty_text",
                 severity: "warning",
-                shapeIds: [s.id],
-                description: `"${s.name}" has an empty text frame`
+                shapes: [s.name],
+                message: `"${s.name}" has an empty text frame`
               });
             }
           }
@@ -50469,22 +50513,10 @@ ${textParts.join("\n")}` : "\n(no text content)";
           for (const s of shapes) {
             if (s.width < 10 || s.height < 10) {
               issues.push({
-                type: "tiny_shapes",
+                check: "tiny_shapes",
                 severity: "warning",
-                shapeIds: [s.id],
-                description: `"${s.name}" is very small (${s.width.toFixed(1)} x ${s.height.toFixed(1)} pt)`
-              });
-            }
-          }
-        }
-        if (enabledChecks.includes("unused_placeholder")) {
-          for (const s of shapes) {
-            if (s.isPlaceholder && !s.hasText) {
-              issues.push({
-                type: "unused_placeholder",
-                severity: "warning",
-                shapeIds: [s.id],
-                description: `"${s.name}" is an unused placeholder \u2014 delete it or fill it with content`
+                shapes: [s.name],
+                message: `"${s.name}" is very small (${s.width.toFixed(1)} x ${s.height.toFixed(1)} pt)`
               });
             }
           }
@@ -50652,293 +50684,6 @@ ${textParts.join("\n")}` : "\n(no text content)";
     }
   );
   server.tool(
-    "search_text",
-    "Search for text across all slides (or a slide range) in the presentation \u2014 like grep for slides. Searches shape text, table cells, and speaker notes. Returns matching shapes with context at the chosen level. Case-insensitive substring by default; supports regex.",
-    {
-      query: external_exports3.string().describe("Text to search for. Plain substring by default, or a regex pattern when regex=true."),
-      slideRange: external_exports3.string().optional().describe('Optional slide range to search, e.g. "0-4" or "2-7". Zero-based. Omit to search all slides.'),
-      caseSensitive: external_exports3.boolean().optional().describe("Case-sensitive search. Default: false."),
-      regex: external_exports3.boolean().optional().describe("Treat query as a regular expression. Default: false (plain substring)."),
-      context: external_exports3.enum(["shape", "slide", "none"]).optional().describe(
-        'Result detail level. "shape" (default): matching shapes with text. "slide": all shapes on matching slides with matched markers. "none": just matching slide indices.'
-      ),
-      includeNotes: external_exports3.boolean().optional().describe("Search speaker notes in addition to slide content. Default: true."),
-      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
-    },
-    async ({ query, slideRange, caseSensitive, regex, context: contextLevel, includeNotes, presentationId }) => {
-      try {
-        const cs = caseSensitive === true;
-        const useRegex = regex === true;
-        const ctxLevel = contextLevel ?? "shape";
-        const searchNotes = includeNotes !== false;
-        const escapedQuery = JSON.stringify(query);
-        const code = `
-          var caseSensitive = ${cs};
-          var useRegex = ${useRegex};
-          var query = ${escapedQuery};
-          var ctxLevel = ${JSON.stringify(ctxLevel)};
-          var searchNotes = ${searchNotes};
-          var slideRangeStr = ${slideRange ? JSON.stringify(slideRange) : "null"};
-
-          function testMatch(text) {
-            if (useRegex) {
-              var flags = caseSensitive ? "" : "i";
-              var re = new RegExp(query, flags);
-              return re.test(text);
-            }
-            var a = caseSensitive ? text : text.toLowerCase();
-            var b = caseSensitive ? query : query.toLowerCase();
-            return a.indexOf(b) !== -1;
-          }
-
-          function extractShapeTexts(shapes) {
-            var results = [];
-            for (var j = 0; j < shapes.items.length; j++) {
-              var shape = shapes.items[j];
-              var texts = [];
-              try {
-                shape.textFrame.load("textRange");
-                try { shape.textFrame.textRange.load("text"); } catch(e) {}
-              } catch (e) {}
-              try {
-                if (shape.type === "Table") {
-                  shape.table.load("rowCount,columnCount");
-                }
-              } catch (e) {}
-            }
-            return shapes;
-          }
-
-          var slides = context.presentation.slides;
-          slides.load("items");
-          await context.sync();
-          var total = slides.items.length;
-          var startIdx = 0;
-          var endIdx = total - 1;
-          if (slideRangeStr) {
-            var parts = slideRangeStr.split("-");
-            startIdx = parseInt(parts[0], 10);
-            if (parts.length > 1) endIdx = parseInt(parts[1], 10);
-            else endIdx = startIdx;
-            if (startIdx < 0) startIdx = 0;
-            if (endIdx >= total) endIdx = total - 1;
-          }
-
-          var slideResults = [];
-          for (var si = startIdx; si <= endIdx; si++) {
-            var slide = slides.items[si];
-            slide.shapes.load("items");
-            await context.sync();
-
-            var shapeEntries = [];
-            var slideHasMatch = false;
-
-            for (var j = 0; j < slide.shapes.items.length; j++) {
-              var shape = slide.shapes.items[j];
-              var shapeId = String(shape.id);
-              var shapeName = shape.name;
-              var shapeType = shape.type;
-              var texts = [];
-
-              try {
-                shape.textFrame.load("textRange");
-                await context.sync();
-                var t = shape.textFrame.textRange.text;
-                if (t) texts.push({ source: "shape", text: t });
-              } catch (e) {}
-
-              if (shapeType === "Table") {
-                try {
-                  shape.table.load("rowCount,columnCount");
-                  await context.sync();
-                  var rc = shape.table.rowCount;
-                  var cc = shape.table.columnCount;
-                  for (var r = 0; r < rc; r++) {
-                    for (var c = 0; c < cc; c++) {
-                      try {
-                        var cell = shape.table.getCell(r, c);
-                        cell.body.load("text");
-                        await context.sync();
-                        if (cell.body.text) texts.push({ source: "tableCell", text: cell.body.text, row: r, col: c });
-                      } catch (e2) {}
-                    }
-                  }
-                } catch (e) {}
-              }
-
-              var matched = false;
-              for (var ti = 0; ti < texts.length; ti++) {
-                if (testMatch(texts[ti].text)) { matched = true; break; }
-              }
-
-              if (matched) slideHasMatch = true;
-
-              shapeEntries.push({
-                shapeId: shapeId,
-                shapeName: shapeName,
-                shapeType: shapeType,
-                matched: matched,
-                texts: texts
-              });
-            }
-
-            var noteText = null;
-            var noteMatched = false;
-            if (searchNotes) {
-              try {
-                var ns = slide.notesSlide;
-                ns.shapes.load("items");
-                await context.sync();
-                for (var ni = 0; ni < ns.shapes.items.length; ni++) {
-                  try {
-                    ns.shapes.items[ni].textFrame.load("textRange");
-                    await context.sync();
-                    var nt = ns.shapes.items[ni].textFrame.textRange.text;
-                    if (nt && nt.trim()) {
-                      noteText = (noteText || "") + nt;
-                    }
-                  } catch (e) {}
-                }
-                if (noteText && testMatch(noteText)) {
-                  noteMatched = true;
-                  slideHasMatch = true;
-                }
-              } catch (e) {}
-            }
-
-            if (slideHasMatch) {
-              if (ctxLevel === "none") {
-                slideResults.push(si);
-              } else if (ctxLevel === "slide") {
-                var entry = { slideIndex: si, shapes: [] };
-                for (var k = 0; k < shapeEntries.length; k++) {
-                  var se = shapeEntries[k];
-                  var shapeInfo = {
-                    shapeId: se.shapeId,
-                    shapeName: se.shapeName,
-                    matched: se.matched
-                  };
-                  for (var ti2 = 0; ti2 < se.texts.length; ti2++) {
-                    var tx = se.texts[ti2];
-                    if (tx.source === "shape") shapeInfo.text = tx.text;
-                    else if (tx.source === "tableCell") {
-                      if (!shapeInfo.tableCells) shapeInfo.tableCells = [];
-                      shapeInfo.tableCells.push({ row: tx.row, col: tx.col, text: tx.text, matched: testMatch(tx.text) });
-                    }
-                  }
-                  entry.shapes.push(shapeInfo);
-                }
-                if (noteText) entry.notes = { text: noteText, matched: noteMatched };
-                slideResults.push(entry);
-              } else {
-                for (var k2 = 0; k2 < shapeEntries.length; k2++) {
-                  var se2 = shapeEntries[k2];
-                  if (!se2.matched) continue;
-                  for (var ti3 = 0; ti3 < se2.texts.length; ti3++) {
-                    var tx2 = se2.texts[ti3];
-                    if (!testMatch(tx2.text)) continue;
-                    var m = { slideIndex: si, shapeId: se2.shapeId, shapeName: se2.shapeName, source: tx2.source, text: tx2.text };
-                    if (tx2.source === "tableCell") { m.row = tx2.row; m.col = tx2.col; }
-                    slideResults.push(m);
-                  }
-                }
-                if (noteMatched) {
-                  slideResults.push({ slideIndex: si, source: "note", text: noteText });
-                }
-              }
-            }
-          }
-
-          var result = { query: query, caseSensitive: caseSensitive, regex: useRegex, totalSlides: total };
-          if (ctxLevel === "none") {
-            result.matchingSlides = slideResults;
-          } else {
-            result.matches = slideResults;
-          }
-          return result;
-        `;
-        const target = pool2.resolveTarget(presentationId);
-        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
-        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
-        const text = JSON.stringify(result, null, 2) + (warning ?? "");
-        return { content: [{ type: "text", text }] };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
-      }
-    }
-  );
-  server.tool(
-    "format_shapes",
-    "Apply formatting to multiple shapes on a slide in one call. Generates Office.js code internally. Use for fill color, font bold/italic/size/color/name. Cannot set corner radius or borders (use edit_slide_xml code mode for those).",
-    {
-      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
-      shapes: external_exports3.array(
-        external_exports3.object({
-          id: external_exports3.string().describe("Shape ID from inspect_slide or scan_slide"),
-          fill: external_exports3.string().optional().describe('Fill color as hex without # (e.g., "1A1A1E")'),
-          font: external_exports3.object({
-            bold: external_exports3.boolean().optional(),
-            italic: external_exports3.boolean().optional(),
-            size: external_exports3.number().optional().describe("Font size in points"),
-            color: external_exports3.string().optional().describe('Font color as hex without # (e.g., "FFFFFF")'),
-            name: external_exports3.string().optional().describe('Font name (e.g., "Calibri")')
-          }).optional()
-        })
-      ).min(1).describe("Shapes to format with their properties"),
-      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
-    },
-    async ({ slideIndex, shapes, presentationId }) => {
-      try {
-        const target = pool2.resolveTarget(presentationId);
-        const shapeOps = shapes.map((s) => {
-          const lines = [];
-          lines.push(`  var s = shapeMap["${s.id}"];`);
-          lines.push(
-            `  if (!s) throw new Error("Shape " + ${JSON.stringify(s.id)} + " not found on slide ${slideIndex}");`
-          );
-          if (s.fill) {
-            lines.push(`  s.fill.setSolidColor("${s.fill}");`);
-          }
-          if (s.font) {
-            lines.push(`  var tf = s.getTextFrameOrNullObject();`);
-            lines.push(`  await context.sync();`);
-            lines.push(`  if (!tf.isNullObject) {`);
-            lines.push(`    var tr = tf.textRange;`);
-            if (s.font.bold !== void 0) lines.push(`    tr.font.bold = ${s.font.bold};`);
-            if (s.font.italic !== void 0) lines.push(`    tr.font.italic = ${s.font.italic};`);
-            if (s.font.size !== void 0) lines.push(`    tr.font.size = ${s.font.size};`);
-            if (s.font.color !== void 0) lines.push(`    tr.font.color = "${s.font.color}";`);
-            if (s.font.name !== void 0) lines.push(`    tr.font.name = "${s.font.name}";`);
-            lines.push(`  }`);
-          }
-          return lines.join("\n");
-        }).join("\n");
-        const code = `
-var slides = context.presentation.slides;
-slides.load("items");
-await context.sync();
-var slide = slides.items[${slideIndex}];
-slide.shapes.load("items");
-await context.sync();
-var shapeMap = {};
-for (var i = 0; i < slide.shapes.items.length; i++) {
-  shapeMap[slide.shapes.items[i].id] = slide.shapes.items[i];
-}
-${shapeOps}
-await context.sync();
-return { success: true, shapesFormatted: ${shapes.length} };`;
-        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
-        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
-        const text = JSON.stringify(result ?? { success: true }, null, 2) + (warning ?? "");
-        return { content: [{ type: "text", text }] };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
-      }
-    }
-  );
-  server.tool(
     "execute_officejs",
     "Execute arbitrary Office.js code inside the live PowerPoint presentation. The code runs inside PowerPoint.run(async (context) => { ... }) with 'context' available as a variable. Use 'await context.sync()' after loading properties. Return a value to get it back as the tool result. For positioning, all values are in points (1 point = 1/72 inch). Common operations: add shapes, set text, change colors, add/delete slides.",
     {
@@ -50960,70 +50705,92 @@ return { success: true, shapesFormatted: ${shapes.length} };`;
       }
     }
   );
-}
-
-// server/version-check.ts
-async function checkForUpdate(options) {
-  const {
-    currentVersion,
-    packageName = "powerpoint-bridge",
-    registryUrl = "https://registry.npmjs.org",
-    timeoutMs = 3e3
-  } = options;
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(`${registryUrl}/${packageName}/latest`, {
-      signal: controller.signal,
-      headers: { Accept: "application/json" }
-    });
-    clearTimeout(timer);
-    if (!res.ok) return null;
-    const data = await res.json();
-    const latest = data.version;
-    if (!latest) return null;
-    return {
-      latest,
-      current: currentVersion,
-      updateAvailable: isNewer(latest, currentVersion)
-    };
-  } catch {
-    return null;
-  }
-}
-function isNewer(latest, current) {
-  const parse3 = (v) => v.replace(/^v/, "").split("-")[0].split(".").map(Number);
-  const [lMajor = 0, lMinor = 0, lPatch = 0] = parse3(latest);
-  const [cMajor = 0, cMinor = 0, cPatch = 0] = parse3(current);
-  if (lMajor !== cMajor) return lMajor > cMajor;
-  if (lMinor !== cMinor) return lMinor > cMinor;
-  return lPatch > cPatch;
-}
-function runVersionCheck(currentVersion) {
-  if (process.env.BRIDGE_NO_UPDATE_CHECK === "1") return;
-  if (process.argv.includes("--no-update-check")) return;
-  checkForUpdate({ currentVersion }).then((result) => {
-    if (result?.updateAvailable) {
-      console.error(
-        `
-  Update available: v${result.current} \u2192 v${result.latest}
-  Run "npm update -g powerpoint-bridge" to upgrade
-`
-      );
+  server.tool(
+    "search_icons",
+    'Search Microsoft Fluent UI icon library. Returns matching icons with IDs for use with insert_icon. Prefer mono (_M) variants for professional decks. Retry with synonyms if no good matches (e.g. "innovation" \u2192 "lightbulb", "security" \u2192 "shield").',
+    {
+      query: external_exports3.string().describe('Search query (e.g. "warning", "arrow down", "lightbulb")'),
+      top: external_exports3.number().int().min(1).max(50).optional().describe("Max results to return (default 10)"),
+      style: external_exports3.enum(["regular", "filled"]).optional().describe('Filter by style: "regular" for mono/outline icons, "filled" for solid icons. Omit for both.')
+    },
+    async ({ query, top, style }) => {
+      try {
+        const results = await searchIcons(query, top ?? 10, style);
+        return { content: [{ type: "text", text: JSON.stringify(results, null, 2) }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+      }
     }
-  });
+  );
+  server.tool(
+    "insert_icon",
+    "Insert a Fluent UI icon onto a slide. Fetches SVG from CDN, optionally recolors it, and inserts via Office.js. Use search_icons first to find the icon ID. Pass color as hex to tint mono icons.",
+    {
+      iconId: external_exports3.string().describe('Icon ID from search_icons (e.g. "Icons_Warning_M" for mono, "Icons_Warning" for filled)'),
+      slideIndex: external_exports3.number().int().min(0).optional().describe("Zero-based slide index. If omitted, inserts on the currently active slide."),
+      x: external_exports3.number().optional().describe("Horizontal position in points (1 point = 1/72 inch)"),
+      y: external_exports3.number().optional().describe("Vertical position in points"),
+      width: external_exports3.number().optional().describe("Icon width in points (default 72)"),
+      height: external_exports3.number().optional().describe("Icon height in points (default 72)"),
+      color: external_exports3.string().optional().describe('Hex color to tint the icon (e.g. "#FF5733"). Works best with mono (_M) icons.'),
+      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
+    },
+    async ({ iconId, slideIndex, x, y, width, height, color, presentationId }) => {
+      try {
+        const base64Data = await fetchIconSvg(iconId, color);
+        const optionsParts = ["coercionType: Office.CoercionType.Image"];
+        if (x !== void 0) optionsParts.push(`imageLeft: ${x}`);
+        if (y !== void 0) optionsParts.push(`imageTop: ${y}`);
+        if (width !== void 0) optionsParts.push(`imageWidth: ${width}`);
+        if (height !== void 0) optionsParts.push(`imageHeight: ${height}`);
+        const optionsStr = `{ ${optionsParts.join(", ")} }`;
+        const insertCall = `Office.context.document.setSelectedDataAsync("${base64Data}", ${optionsStr}, function(result) {
+        if (result.status === Office.AsyncResultStatus.Succeeded) {
+          resolve({ success: true });
+        } else {
+          reject(new Error(result.error.message));
+        }
+      });`;
+        let code;
+        if (slideIndex !== void 0) {
+          code = `return new Promise(function(resolve, reject) {
+      Office.context.document.goToByIdAsync(${slideIndex + 1}, Office.GoToType.Index, function(navResult) {
+        if (navResult.status !== Office.AsyncResultStatus.Succeeded) {
+          reject(new Error("Navigation failed: " + navResult.error.message));
+          return;
+        }
+        ${insertCall}
+      });
+    });`;
+        } else {
+          code = `return new Promise(function(resolve, reject) {
+      ${insertCall}
+    });`;
+        }
+        const target = pool2.resolveTarget(presentationId);
+        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
+        const text = JSON.stringify(result ?? { success: true, iconId }, null, 2) + (warning ?? "");
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
 }
 
 // server/index.ts
-var import_meta = {};
+var import_meta2 = {};
 var BRIDGE_DEFAULT_HTTP_PORT = 8080;
 var BRIDGE_DEFAULT_HTTPS_PORT = 8443;
 var MCP_HTTP_PORT = Number(process.env.MCP_PORT) || 3001;
-var SCRIPT_DIR = typeof __dirname !== "undefined" ? __dirname : (0, import_node_path2.dirname)((0, import_node_url.fileURLToPath)(import_meta.url));
-var PROJECT_ROOT = (0, import_node_path2.resolve)(SCRIPT_DIR, "..");
-var BRIDGE_CERT_PATH = (0, import_node_path2.resolve)(PROJECT_ROOT, "certs", "localhost.pem");
-var BRIDGE_KEY_PATH = (0, import_node_path2.resolve)(PROJECT_ROOT, "certs", "localhost-key.pem");
-var ADDIN_STATIC_DIR = (0, import_node_path2.resolve)(PROJECT_ROOT, "addin");
+var SCRIPT_DIR = typeof __dirname !== "undefined" ? __dirname : (0, import_node_path3.dirname)((0, import_node_url2.fileURLToPath)(import_meta2.url));
+var PROJECT_ROOT = (0, import_node_path3.resolve)(SCRIPT_DIR, "..");
+var BRIDGE_CERT_PATH = (0, import_node_path3.resolve)(PROJECT_ROOT, "certs", "localhost.pem");
+var BRIDGE_KEY_PATH = (0, import_node_path3.resolve)(PROJECT_ROOT, "certs", "localhost-key.pem");
+var ADDIN_STATIC_DIR = (0, import_node_path3.resolve)(PROJECT_ROOT, "addin");
 var cliArgs = process.argv.slice(2);
 var enableStdio = cliArgs.includes("--stdio");
 var enableHttp = cliArgs.includes("--http");
@@ -51058,7 +50825,7 @@ Flags (composable):
   process.exit(1);
 }
 var bridgeTls = process.env.BRIDGE_TLS === "1";
-if (bridgeActive && bridgeTls && (!(0, import_node_fs2.existsSync)(BRIDGE_CERT_PATH) || !(0, import_node_fs2.existsSync)(BRIDGE_KEY_PATH))) {
+if (bridgeActive && bridgeTls && (!(0, import_node_fs3.existsSync)(BRIDGE_CERT_PATH) || !(0, import_node_fs3.existsSync)(BRIDGE_KEY_PATH))) {
   console.error(
     `Error: BRIDGE_TLS=1 but TLS certificate files not found.
   Expected: ${BRIDGE_CERT_PATH} and ${BRIDGE_KEY_PATH}
@@ -51068,17 +50835,17 @@ if (bridgeActive && bridgeTls && (!(0, import_node_fs2.existsSync)(BRIDGE_CERT_P
 }
 var BRIDGE_PORT = Number(process.env.BRIDGE_PORT) || (bridgeTls ? BRIDGE_DEFAULT_HTTPS_PORT : BRIDGE_DEFAULT_HTTP_PORT);
 function autoSideloadManifest(tls, port) {
-  const markerFile = (0, import_node_path2.resolve)(PROJECT_ROOT, ".sideloaded");
-  const pkgPath = (0, import_node_path2.resolve)(PROJECT_ROOT, "package.json");
+  const markerFile = (0, import_node_path3.resolve)(PROJECT_ROOT, ".sideloaded");
+  const pkgPath = (0, import_node_path3.resolve)(PROJECT_ROOT, "package.json");
   let currentVersion = "unknown";
   try {
-    const pkg = JSON.parse((0, import_node_fs2.readFileSync)(pkgPath, "utf8"));
+    const pkg = JSON.parse((0, import_node_fs3.readFileSync)(pkgPath, "utf8"));
     currentVersion = pkg.version;
   } catch {
   }
   const markerValue = `${currentVersion}:${port}`;
   try {
-    const existing = (0, import_node_fs2.readFileSync)(markerFile, "utf8").trim();
+    const existing = (0, import_node_fs3.readFileSync)(markerFile, "utf8").trim();
     if (existing === markerValue) {
       console.error("[sideload] Add-in already installed (use `npm run sideload` to update)");
       return;
@@ -51087,17 +50854,17 @@ function autoSideloadManifest(tls, port) {
   } catch {
   }
   const defaultPort = tls ? BRIDGE_DEFAULT_HTTPS_PORT : BRIDGE_DEFAULT_HTTP_PORT;
-  const wefDir = (0, import_node_path2.join)((0, import_node_os2.homedir)(), "Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef");
+  const wefDir = (0, import_node_path3.join)((0, import_node_os2.homedir)(), "Library/Containers/com.microsoft.Powerpoint/Data/Documents/wef");
   const manifestName = tls ? "manifest-https.xml" : "manifest.xml";
-  const src = (0, import_node_path2.resolve)(ADDIN_STATIC_DIR, manifestName);
-  const dest = (0, import_node_path2.join)(wefDir, "manifest.xml");
+  const src = (0, import_node_path3.resolve)(ADDIN_STATIC_DIR, manifestName);
+  const dest = (0, import_node_path3.join)(wefDir, "manifest.xml");
   try {
-    if (!(0, import_node_fs2.existsSync)(src)) return;
-    const template = (0, import_node_fs2.readFileSync)(src, "utf8");
+    if (!(0, import_node_fs3.existsSync)(src)) return;
+    const template = (0, import_node_fs3.readFileSync)(src, "utf8");
     const content = substituteManifestPort(template, defaultPort, port);
-    (0, import_node_fs2.mkdirSync)(wefDir, { recursive: true });
-    (0, import_node_fs2.writeFileSync)(dest, content);
-    (0, import_node_fs2.writeFileSync)(markerFile, markerValue);
+    (0, import_node_fs3.mkdirSync)(wefDir, { recursive: true });
+    (0, import_node_fs3.writeFileSync)(dest, content);
+    (0, import_node_fs3.writeFileSync)(markerFile, markerValue);
     console.error("[sideload] Add-in manifest installed for PowerPoint");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -51123,7 +50890,7 @@ var MIME_TYPES = {
   ".ico": "image/x-icon"
 };
 function getMimeType(filePath) {
-  const ext = (0, import_node_path2.extname)(filePath);
+  const ext = (0, import_node_path3.extname)(filePath);
   return MIME_TYPES[ext] ?? "application/octet-stream";
 }
 function parseJsonBody(req) {
@@ -51240,24 +51007,24 @@ function serveStatic(req, res) {
     return;
   }
   const urlPath = rawUrl === "/" ? "/index.html" : rawUrl;
-  const filePath = (0, import_node_path2.resolve)((0, import_node_path2.join)(ADDIN_STATIC_DIR, urlPath));
+  const filePath = (0, import_node_path3.resolve)((0, import_node_path3.join)(ADDIN_STATIC_DIR, urlPath));
   if (!filePath.startsWith(ADDIN_STATIC_DIR)) {
     res.writeHead(403, { "Content-Type": "text/plain" });
     res.end("403 Forbidden");
     return;
   }
-  if (!(0, import_node_fs2.existsSync)(filePath)) {
+  if (!(0, import_node_fs3.existsSync)(filePath)) {
     res.writeHead(404, { "Content-Type": "text/plain" });
     res.end("404 Not Found");
     return;
   }
-  const content = (0, import_node_fs2.readFileSync)(filePath);
+  const content = (0, import_node_fs3.readFileSync)(filePath);
   res.writeHead(200, { "Content-Type": getMimeType(filePath) });
   res.end(content);
 }
 if (bridgeActive) {
   autoSideloadManifest(bridgeTls, BRIDGE_PORT);
-  const bridgeServer = bridgeTls ? (0, import_node_https.createServer)({ cert: (0, import_node_fs2.readFileSync)(BRIDGE_CERT_PATH), key: (0, import_node_fs2.readFileSync)(BRIDGE_KEY_PATH) }, serveStatic) : (0, import_node_http.createServer)(serveStatic);
+  const bridgeServer = bridgeTls ? (0, import_node_https.createServer)({ cert: (0, import_node_fs3.readFileSync)(BRIDGE_CERT_PATH), key: (0, import_node_fs3.readFileSync)(BRIDGE_KEY_PATH) }, serveStatic) : (0, import_node_http.createServer)(serveStatic);
   const wss = new import_websocket_server.default({ server: bridgeServer });
   wss.on("connection", (ws) => {
     console.error("Add-in WebSocket connected");
@@ -51364,11 +51131,6 @@ if (stdioActive) {
   stdioMcpServer.connect(stdioTransport).then(() => {
     console.error("MCP STDIO transport running");
   });
-}
-try {
-  const pkg = JSON.parse((0, import_node_fs2.readFileSync)((0, import_node_path2.resolve)(PROJECT_ROOT, "package.json"), "utf8"));
-  runVersionCheck(pkg.version);
-} catch {
 }
 var activeInterfaces = [
   stdioActive && "STDIO",

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -14725,10 +14725,10 @@ var require_dom_parser = __commonJS({
     function normalizeLineEndings(input) {
       return input.replace(/\r[\n\u0085]/g, "\n").replace(/[\r\u0085\u2028]/g, "\n");
     }
-    function DOMParser2(options) {
+    function DOMParser3(options) {
       this.options = options || { locator: {} };
     }
-    DOMParser2.prototype.parseFromString = function(source, mimeType) {
+    DOMParser3.prototype.parseFromString = function(source, mimeType) {
       var options = this.options;
       var sax2 = new XMLReader();
       var domBuilder = options.domBuilder || new DOMHandler();
@@ -14923,7 +14923,7 @@ var require_dom_parser = __commonJS({
     }
     exports2.__DOMHandler = DOMHandler;
     exports2.normalizeLineEndings = normalizeLineEndings;
-    exports2.DOMParser = DOMParser2;
+    exports2.DOMParser = DOMParser3;
   }
 });
 
@@ -49162,6 +49162,7 @@ function substituteManifestPort(content, defaultPort, targetPort) {
 var import_node_fs2 = require("node:fs");
 var import_node_os = require("node:os");
 var import_node_path2 = require("node:path");
+var import_xmldom2 = __toESM(require_lib(), 1);
 
 // server/chart-builder.ts
 var C_NS = "http://schemas.openxmlformats.org/drawingml/2006/chart";
@@ -49358,7 +49359,6 @@ var MANIFEST_URL = "https://raw.githubusercontent.com/microsoft/fluentui-system-
 var CDN_BASE = "https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets";
 var DEFAULT_SIZE = 24;
 var cachedIndex = null;
-var svgCache = /* @__PURE__ */ new Map();
 function snakeToTitle(s) {
   return s.split("_").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
 }
@@ -49368,18 +49368,6 @@ function titleToSnake(s) {
 function nameToId(name, mono) {
   const base = `Icons_${name.replace(/\s+/g, "_")}`;
   return mono ? `${base}_M` : base;
-}
-function parseIconId(iconId) {
-  let id = iconId;
-  let isMono = false;
-  if (id.endsWith("_M")) {
-    isMono = true;
-    id = id.slice(0, -2);
-  }
-  if (id.startsWith("Icons_")) {
-    id = id.slice(6);
-  }
-  return { snakeName: id.toLowerCase(), isMono };
 }
 function buildIndexFromManifest(manifest) {
   const seen = /* @__PURE__ */ new Set();
@@ -49472,14 +49460,16 @@ async function searchIcons(query, top = 10, style) {
         description: `${entry.name} (mono/outline)`,
         isMono: true,
         contentTier: "free",
-        searchScore: score
+        searchScore: score,
+        svgUrl: buildSvgUrl(entry.snakeName, true)
       });
       results.push({
         id: nameToId(entry.name, false),
         description: `${entry.name} (filled)`,
         isMono: false,
         contentTier: "free",
-        searchScore: score
+        searchScore: score,
+        svgUrl: buildSvgUrl(entry.snakeName, false)
       });
     }
     return results.slice(0, top);
@@ -49489,7 +49479,8 @@ async function searchIcons(query, top = 10, style) {
     description: `${entry.name} (${isMono ? "mono/outline" : "filled"})`,
     isMono,
     contentTier: "free",
-    searchScore: score
+    searchScore: score,
+    svgUrl: buildSvgUrl(entry.snakeName, isMono)
   }));
 }
 function buildSvgUrl(snakeName, isMono) {
@@ -49507,24 +49498,6 @@ function recolorSvg(svg, color) {
     '$1 class="icon-color"$2'
   );
   return result;
-}
-async function fetchIconSvg(iconId, color) {
-  const { snakeName, isMono } = parseIconId(iconId);
-  const cacheKey2 = `${snakeName}:${isMono ? "regular" : "filled"}`;
-  let svg = svgCache.get(cacheKey2);
-  if (!svg) {
-    const url2 = buildSvgUrl(snakeName, isMono);
-    const resp = await fetch(url2);
-    if (!resp.ok) {
-      throw new Error(`Failed to fetch icon SVG: ${resp.status} ${resp.statusText} (${url2})`);
-    }
-    svg = await resp.text();
-    svgCache.set(cacheKey2, svg);
-  }
-  if (color) {
-    svg = recolorSvg(svg, color);
-  }
-  return Buffer.from(svg).toString("base64");
 }
 
 // server/xml-helpers.ts
@@ -49557,6 +49530,7 @@ async function reimportSlide(pool2, modifiedBase64, slideId, prevSlideId, target
     var slides = context.presentation.slides;
     slides.load("items");
     await context.sync();
+    var countBefore = slides.items.length;
     // Find and delete the original slide by ID
     var found = false;
     for (var i = 0; i < slides.items.length; i++) {
@@ -49569,16 +49543,24 @@ async function reimportSlide(pool2, modifiedBase64, slideId, prevSlideId, target
     if (!found) {
       throw new Error("Original slide not found for reimport (ID: ${slideId})");
     }
-    await context.sync();
-    // Insert modified slide at the correct position
+    // Batch delete + insert in one sync to reduce the window for partial failure
     context.presentation.insertSlidesFromBase64("${modifiedBase64}", ${optionsStr});
     await context.sync();
+    // Verify slide count is unchanged (deleted one, inserted one)
+    slides.load("items");
+    await context.sync();
+    if (slides.items.length !== countBefore) {
+      throw new Error("Reimport verification failed: expected " + countBefore + " slides but found " + slides.items.length);
+    }
     return { success: true };
   `;
   await pool2.sendCommand("executeCode", { code }, targetWs, timeout);
 }
 var NS_P = "http://schemas.openxmlformats.org/presentationml/2006/main";
 var NS_A = "http://schemas.openxmlformats.org/drawingml/2006/main";
+function escapeXml(text) {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
 function parseSlideXml(xmlString) {
   return new import_xmldom.DOMParser().parseFromString(xmlString, "text/xml");
 }
@@ -49771,32 +49753,107 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
     }
   );
   server.tool(
-    "get_presentation",
-    "Returns the structure of the currently open PowerPoint presentation including all slides with their IDs and shape summaries (count, names, types). Use this first to understand what's in the presentation before making changes.",
+    "list_slides",
+    "Lightweight deck index (~5 tokens/slide): returns slide dimensions (slideWidth, slideHeight) and all slides with index, ID, and shape count. Use as the first call to understand deck structure. For shape details, follow up with scan_slide or inspect_slide on specific slides.",
     {
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
     async ({ presentationId }) => {
       try {
         const code = `
-          var slides = context.presentation.slides;
+          var p = context.presentation;
+          var slides = p.slides;
+          var ps = p.pageSetup;
           slides.load("items");
-          await context.sync();
-          for (var i = 0; i < slides.items.length; i++) {
-            slides.items[i].shapes.load("items");
-          }
+          ps.load("slideWidth,slideHeight");
           await context.sync();
           var output = [];
           for (var i = 0; i < slides.items.length; i++) {
             var slide = slides.items[i];
+            slide.shapes.load("items");
+          }
+          await context.sync();
+          for (var i = 0; i < slides.items.length; i++) {
+            var slide = slides.items[i];
+            output.push({ index: i, id: slide.id, shapeCount: slide.shapes.items.length });
+          }
+          return { slideWidth: ps.slideWidth, slideHeight: ps.slideHeight, slides: output };
+        `;
+        const target = pool2.resolveTarget(presentationId);
+        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
+        const text = JSON.stringify(result, null, 2) + (warning ?? "");
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+  server.tool(
+    "inspect_slide",
+    "Detailed slide inspector (~80 tokens/shape): returns every shape with text content, positions, sizes, and fill colors, plus slide dimensions. Supports slideRange for multiple slides. For just positions without text/fills, use scan_slide instead.",
+    {
+      slideRange: external_exports3.string().describe('Slide indices to inspect, e.g. "0", "0-5", "2,4,7". Single index or range.'),
+      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
+    },
+    async ({ slideRange, presentationId }) => {
+      try {
+        const indices = parseSlideRange(slideRange) ?? [];
+        if (indices.length === 0) throw new Error("slideRange is required");
+        const indicesJs = JSON.stringify(indices);
+        const code = `
+          var p = context.presentation;
+          var slides = p.slides;
+          var ps = p.pageSetup;
+          slides.load("items");
+          ps.load("slideWidth,slideHeight");
+          await context.sync();
+          var requestedIndices = ${indicesJs};
+          for (var i = 0; i < requestedIndices.length; i++) {
+            if (requestedIndices[i] >= slides.items.length) {
+              throw new Error("Slide index " + requestedIndices[i] + " out of range (presentation has " + slides.items.length + " slides)");
+            }
+          }
+          for (var i = 0; i < requestedIndices.length; i++) {
+            slides.items[requestedIndices[i]].shapes.load("items");
+          }
+          await context.sync();
+          var output = [];
+          for (var i = 0; i < requestedIndices.length; i++) {
+            var idx = requestedIndices[i];
+            var slide = slides.items[idx];
             var shapes = [];
             for (var j = 0; j < slide.shapes.items.length; j++) {
               var s = slide.shapes.items[j];
-              shapes.push({ name: s.name, type: s.type, id: s.id });
+              var info = {
+                name: s.name,
+                type: s.type,
+                id: s.id,
+                left: s.left,
+                top: s.top,
+                width: s.width,
+                height: s.height
+              };
+              try {
+                s.textFrame.load("textRange");
+                await context.sync();
+                info.text = s.textFrame.textRange.text;
+              } catch (e) {
+                // Shape has no text frame (e.g., images, connectors)
+              }
+              try {
+                s.fill.load("foregroundColor,type");
+                await context.sync();
+                info.fill = { type: s.fill.type, color: s.fill.foregroundColor };
+              } catch (e) {
+                // Shape has no fill or fill not accessible
+              }
+              shapes.push(info);
             }
-            output.push({ index: i, id: slide.id, shapeCount: shapes.length, shapes: shapes });
+            output.push({ slideIndex: idx, slideId: slide.id, shapes: shapes });
           }
-          return output;
+          return { slideWidth: ps.slideWidth, slideHeight: ps.slideHeight, slides: output };
         `;
         const target = pool2.resolveTarget(presentationId);
         const result = await pool2.sendCommand("executeCode", { code }, target.ws);
@@ -49810,53 +49867,54 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
     }
   );
   server.tool(
-    "get_slide",
-    "Returns detailed information about all shapes on a specific slide, including text content, positions (left, top in points), sizes (width, height in points), and fill colors. Use slideIndex from get_presentation results (zero-based).",
+    "scan_slide",
+    "Lightweight shape scanner (~40 tokens/shape): lists shape IDs, types, and positions on slides, plus slide dimensions. Supports slideRange for multiple slides. For text content and fills, use inspect_slide instead.",
     {
-      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
+      slideRange: external_exports3.string().describe('Slide indices to scan, e.g. "0", "0-5", "2,4,7". Single index or range.'),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
-    async ({ slideIndex, presentationId }) => {
+    async ({ slideRange, presentationId }) => {
       try {
+        const indices = parseSlideRange(slideRange) ?? [];
+        if (indices.length === 0) throw new Error("slideRange is required");
+        const indicesJs = JSON.stringify(indices);
         const code = `
-          var slides = context.presentation.slides;
+          var p = context.presentation;
+          var slides = p.slides;
+          var ps = p.pageSetup;
           slides.load("items");
+          ps.load("slideWidth,slideHeight");
           await context.sync();
-          if (${slideIndex} >= slides.items.length) {
-            throw new Error("Slide index " + ${slideIndex} + " out of range (presentation has " + slides.items.length + " slides)");
+          var requestedIndices = ${indicesJs};
+          for (var i = 0; i < requestedIndices.length; i++) {
+            if (requestedIndices[i] >= slides.items.length) {
+              throw new Error("Slide index " + requestedIndices[i] + " out of range (presentation has " + slides.items.length + " slides)");
+            }
           }
-          var slide = slides.items[${slideIndex}];
-          slide.shapes.load("items");
+          for (var i = 0; i < requestedIndices.length; i++) {
+            slides.items[requestedIndices[i]].shapes.load("items");
+          }
           await context.sync();
-          var shapes = [];
-          for (var i = 0; i < slide.shapes.items.length; i++) {
-            var s = slide.shapes.items[i];
-            var info = {
-              name: s.name,
-              type: s.type,
-              id: s.id,
-              left: s.left,
-              top: s.top,
-              width: s.width,
-              height: s.height
-            };
-            try {
-              s.textFrame.load("textRange");
-              await context.sync();
-              info.text = s.textFrame.textRange.text;
-            } catch (e) {
-              // Shape has no text frame (e.g., images, connectors)
+          var output = [];
+          for (var i = 0; i < requestedIndices.length; i++) {
+            var idx = requestedIndices[i];
+            var slide = slides.items[idx];
+            var shapes = [];
+            for (var j = 0; j < slide.shapes.items.length; j++) {
+              var s = slide.shapes.items[j];
+              shapes.push({
+                id: s.id,
+                name: s.name,
+                type: s.type,
+                left: s.left,
+                top: s.top,
+                width: s.width,
+                height: s.height
+              });
             }
-            try {
-              s.fill.load("foregroundColor,type");
-              await context.sync();
-              info.fill = { type: s.fill.type, color: s.fill.foregroundColor };
-            } catch (e) {
-              // Shape has no fill or fill not accessible
-            }
-            shapes.push(info);
+            output.push({ slideIndex: idx, slideId: slide.id, shapes: shapes });
           }
-          return { slideIndex: ${slideIndex}, slideId: slide.id, shapes: shapes };
+          return { slideWidth: ps.slideWidth, slideHeight: ps.slideHeight, slides: output };
         `;
         const target = pool2.resolveTarget(presentationId);
         const result = await pool2.sendCommand("executeCode", { code }, target.ws);
@@ -49870,10 +49928,10 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
     }
   );
   server.tool(
-    "get_slide_image",
-    "Captures a visual screenshot of a specific slide as a PNG image. Use this to SEE what a slide looks like \u2014 useful for verifying layout after changes or understanding content visually. Requires PowerPoint 16.96+ (PowerPointApi 1.8).",
+    "screenshot_slide",
+    "Slide screenshot (~1000 tokens): captures one slide as PNG image. Use to visually verify layout after changes. Do NOT loop over all slides \u2014 use preview_deck instead.",
     {
-      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
+      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from list_slides results"),
       width: external_exports3.number().int().min(1).max(4096).optional().describe(
         "Image width in pixels. Default: 720. Height auto-calculated to preserve aspect ratio unless also specified."
       ),
@@ -50001,9 +50059,12 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
       top: external_exports3.number().optional().describe("Vertical position in points"),
       width: external_exports3.number().optional().describe("Image width in points"),
       height: external_exports3.number().optional().describe("Image height in points"),
+      color: external_exports3.string().optional().describe(
+        'Hex color to tint SVG images (e.g. "#FF5733"). Only applies to SVG sources. Works best with mono/outline icons.'
+      ),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
-    async ({ source, sourceType, slideIndex, left, top, width, height, presentationId }) => {
+    async ({ source, sourceType, slideIndex, left, top, width, height, color, presentationId }) => {
       try {
         let base64Data;
         if (sourceType === "file") {
@@ -50017,6 +50078,14 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
           base64Data = Buffer.from(buf).toString("base64");
         } else {
           base64Data = source;
+        }
+        if (color) {
+          const svg = Buffer.from(base64Data, "base64").toString("utf-8");
+          if (svg.trimStart().startsWith("<svg") || svg.trimStart().startsWith("<?xml")) {
+            base64Data = Buffer.from(recolorSvg(svg, color)).toString("base64");
+          } else {
+            throw new Error("color parameter only works with SVG images, but the source is not SVG");
+          }
         }
         const optionsParts = ["coercionType: Office.CoercionType.Image"];
         if (left !== void 0) optionsParts.push(`imageLeft: ${left}`);
@@ -50059,8 +50128,8 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
     }
   );
   server.tool(
-    "get_deck_overview",
-    "Returns a visual overview of all (or selected) slides in one call \u2014 thumbnails interleaved with text metadata. Much more efficient than calling get_slide + get_slide_image per slide. Use this to review or audit an entire presentation quickly.",
+    "preview_deck",
+    "Deck preview: batch overview of all/selected slides with optional thumbnails + text. With images: ~900 tokens/slide; text-only (includeImages=false): ~35 tokens/slide. Use for visual review or content audit. Do NOT use to inspect one slide \u2014 use inspect_slide or screenshot_slide instead.",
     {
       slideRange: external_exports3.string().optional().describe('Slide indices to include, e.g. "0-5", "2,4,7", "0-2,5,8-10". Omit for all slides.'),
       imageWidth: external_exports3.number().int().min(120).max(1920).optional().describe("Thumbnail width in pixels. Default: 480. Height auto-calculated to preserve aspect ratio."),
@@ -50074,8 +50143,11 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
         const withImages = includeImages !== false;
         const indicesJs = indices ? JSON.stringify(indices) : "null";
         const code = `
-          var slides = context.presentation.slides;
+          var p = context.presentation;
+          var slides = p.slides;
+          var ps = p.pageSetup;
           slides.load("items");
+          ps.load("slideWidth,slideHeight");
           await context.sync();
           var requestedIndices = ${indicesJs};
           var indicesToProcess = requestedIndices || [];
@@ -50114,14 +50186,14 @@ function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
             slideData.imageBase64 = img.value;` : ""}
             output.push(slideData);
           }
-          return { slideCount: slides.items.length, slides: output };
+          return { slideCount: slides.items.length, slideWidth: ps.slideWidth, slideHeight: ps.slideHeight, slides: output };
         `;
         const target = pool2.resolveTarget(presentationId);
         const result = await pool2.sendCommand("executeCode", { code }, target.ws, 12e4);
         const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
         const content = [];
         const showing = result.slides.length;
-        const header = `Deck overview: ${result.slideCount} total slides, showing ${showing}${warning ?? ""}`;
+        const header = `Deck overview: ${result.slideCount} total slides (${result.slideWidth} x ${result.slideHeight} pt), showing ${showing}${warning ?? ""}`;
         content.push({ type: "text", text: header });
         for (const slide of result.slides) {
           if (slide.imageBase64) {
@@ -50248,8 +50320,8 @@ ${textParts.join("\n")}` : "\n(no text content)";
     "read_slide_text",
     "Read raw OOXML <a:p> paragraphs from a shape's text body. Returns the paragraph XML as a string \u2014 preserves all formatting (bold, colors, bullets, etc.) that textRange.text strips. Use with the /pptx skill's OOXML knowledge to understand and modify the XML.",
     {
-      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
-      shapeId: external_exports3.string().describe('Shape ID from get_slide results (e.g. "5")'),
+      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from list_slides results"),
+      shapeId: external_exports3.string().describe('Shape ID from inspect_slide results (e.g. "5")'),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
     async ({ slideIndex, shapeId, presentationId }) => {
@@ -50275,7 +50347,7 @@ ${textParts.join("\n")}` : "\n(no text content)";
     "Replace paragraph content of a shape with raw OOXML <a:p> XML. Preserves <a:bodyPr> and <a:lstStyle>. Use read_slide_text first to get the current XML, modify it (using /pptx skill knowledge), then write it back. The slide is exported, modified server-side, and reimported \u2014 data never enters Claude's context.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
-      shapeId: external_exports3.string().describe("Shape ID from get_slide results"),
+      shapeId: external_exports3.string().describe("Shape ID from inspect_slide results"),
       xml: external_exports3.string().describe("The <a:p> paragraph XML to replace the current text body content with"),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
@@ -50305,7 +50377,7 @@ ${textParts.join("\n")}` : "\n(no text content)";
     "read_slide_xml",
     "Read the full raw OOXML of a slide, or filter to a specific shape. Returns the slide's ppt/slides/slide1.xml content. Use with the /pptx skill's OOXML knowledge to understand the XML structure.",
     {
-      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from get_presentation results"),
+      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from list_slides results"),
       shapeId: external_exports3.string().optional().describe("Optional shape ID to filter to. If provided, returns only that shape's <p:sp> element."),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
@@ -50331,22 +50403,57 @@ ${textParts.join("\n")}` : "\n(no text content)";
   );
   server.tool(
     "edit_slide_xml",
-    "Replace the full slide XML or a specific shape's XML and reimport. Use read_slide_xml first to get the current XML, modify it, then write it back. The slide is exported, modified server-side, and reimported \u2014 data never enters Claude's context.",
+    "Edit slide XML and reimport. Two modes: (1) xml mode \u2014 provide finished XML string (use read_slide_xml first to get current XML), (2) code mode \u2014 provide JS code that manipulates the pre-parsed DOM (receives: doc, findShapeById, NS_P, NS_A, escapeXml, serializeXml, DOMParser). Code mode preserves untouched attributes. The slide is exported, modified server-side, and reimported \u2014 data never enters Claude's context.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
-      xml: external_exports3.string().describe("Modified XML \u2014 full slide XML or a single shape's <p:sp> element (when shapeId is provided)"),
+      xml: external_exports3.string().optional().describe(
+        "Modified XML \u2014 full slide XML or a single shape's <p:sp> element (when shapeId is provided). Mutually exclusive with 'code'."
+      ),
+      code: external_exports3.string().optional().describe(
+        "JS code that manipulates the pre-parsed slide DOM. Receives: doc (Document), findShapeById(id) \u2192 Element|null, NS_P, NS_A (namespace strings), escapeXml(text), serializeXml(node), DOMParser. Mutually exclusive with 'xml'."
+      ),
+      explanation: external_exports3.string().optional().describe("Brief description of what the code does (for logging, max 50 chars). Only used with code mode."),
       shapeId: external_exports3.string().optional().describe(
-        "Optional shape ID. If provided, replaces only that shape's <p:sp> element instead of the full slide XML."
+        "Optional shape ID (xml mode only). If provided, replaces only that shape's <p:sp> element instead of the full slide XML."
       ),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
-    async ({ slideIndex, xml, shapeId, presentationId }) => {
+    async ({ slideIndex, xml, code, shapeId, presentationId }) => {
+      if (!xml && !code || xml && code) {
+        return {
+          content: [
+            { type: "text", text: "Error: Provide either 'xml' or 'code', not both and not neither." }
+          ],
+          isError: true
+        };
+      }
       try {
         const target = pool2.resolveTarget(presentationId);
         const exported = await exportSlide(pool2, slideIndex, target.ws);
         const { zip, xmlString } = await extractSlideXmlFromZip(exported.base64);
         let finalXml;
-        if (shapeId) {
+        if (code) {
+          const doc = parseSlideXml(xmlString);
+          const sandbox = {
+            doc,
+            findShapeById: (id) => findShapeById(doc, id),
+            NS_P,
+            NS_A,
+            escapeXml,
+            serializeXml: (node) => serializeXml(node),
+            DOMParser: import_xmldom2.DOMParser
+          };
+          try {
+            const keys = Object.keys(sandbox);
+            const values = Object.values(sandbox);
+            const fn = new Function(...keys, code);
+            fn(...values);
+          } catch (codeErr) {
+            const msg = codeErr instanceof Error ? codeErr.message : String(codeErr);
+            throw new Error(`Code execution error: ${msg}`);
+          }
+          finalXml = serializeXml(doc);
+        } else if (shapeId) {
           const doc = parseSlideXml(xmlString);
           const shape = findShapeById(doc, shapeId);
           if (!shape) {
@@ -50417,16 +50524,16 @@ ${textParts.join("\n")}` : "\n(no text content)";
   );
   server.tool(
     "verify_slides",
-    "Run programmatic checks on a slide: detect overlapping shapes, out-of-bounds shapes, empty text, and tiny shapes. Returns a list of issues found. Uses the same shape data as get_slide \u2014 no OOXML needed.",
+    "Run programmatic checks on a slide: detect overlapping shapes, out-of-bounds shapes, empty text, tiny shapes, and unused placeholders. Returns a list of issues found. Uses the same shape data as inspect_slide \u2014 no OOXML needed.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
-      checks: external_exports3.array(external_exports3.enum(["overlap", "bounds", "empty_text", "tiny_shapes"])).optional().describe("Checks to run. Default: all four checks."),
+      checks: external_exports3.array(external_exports3.enum(["overlap", "bounds", "empty_text", "tiny_shapes", "unused_placeholder"])).optional().describe("Checks to run. Default: all five checks."),
       presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
     },
     async ({ slideIndex, checks, presentationId }) => {
       try {
         const target = pool2.resolveTarget(presentationId);
-        const enabledChecks = checks ?? ["overlap", "bounds", "empty_text", "tiny_shapes"];
+        const enabledChecks = checks ?? ["overlap", "bounds", "empty_text", "tiny_shapes", "unused_placeholder"];
         const code = `
           var slides = context.presentation.slides;
           slides.load("items");
@@ -50449,17 +50556,27 @@ ${textParts.join("\n")}` : "\n(no text content)";
               height: s.height
             };
             try {
-              s.textFrame.load("textRange");
+              var tf = s.getTextFrameOrNullObject();
+              tf.load(["hasText", "textRange"]);
               await context.sync();
-              info.text = s.textFrame.textRange.text;
+              if (!tf.isNullObject) {
+                info.text = tf.hasText ? tf.textRange.text : "";
+                info.hasText = tf.hasText;
+              }
+            } catch (e) {}
+            try {
+              var pf = s.getPlaceholderOrNullObject();
+              pf.load("type");
+              await context.sync();
+              if (!pf.isNullObject) info.isPlaceholder = true;
             } catch (e) {}
             shapes.push(info);
           }
           // Also get slide dimensions
-          var p = context.presentation;
-          p.load("slideWidth,slideHeight");
+          var ps = context.presentation.pageSetup;
+          ps.load("slideWidth,slideHeight");
           await context.sync();
-          return { shapes: shapes, slideWidth: p.slideWidth, slideHeight: p.slideHeight };
+          return { shapes: shapes, slideWidth: ps.slideWidth, slideHeight: ps.slideHeight };
         `;
         const slideData = await pool2.sendCommand("executeCode", { code }, target.ws);
         const issues = [];
@@ -50471,10 +50588,10 @@ ${textParts.join("\n")}` : "\n(no text content)";
               const b = shapes[j];
               if (a.left < b.left + b.width && a.left + a.width > b.left && a.top < b.top + b.height && a.top + a.height > b.top) {
                 issues.push({
-                  check: "overlap",
+                  type: "overlap",
                   severity: "warning",
-                  shapes: [a.name, b.name],
-                  message: `"${a.name}" and "${b.name}" overlap`
+                  shapeIds: [a.id, b.id],
+                  description: `"${a.name}" and "${b.name}" overlap`
                 });
               }
             }
@@ -50489,10 +50606,10 @@ ${textParts.join("\n")}` : "\n(no text content)";
             if (s.top + s.height > slideHeight) outOfBounds.push("below slide");
             if (outOfBounds.length > 0) {
               issues.push({
-                check: "bounds",
+                type: "bounds",
                 severity: "warning",
-                shapes: [s.name],
-                message: `"${s.name}" extends ${outOfBounds.join(", ")}`
+                shapeIds: [s.id],
+                description: `"${s.name}" extends ${outOfBounds.join(", ")}`
               });
             }
           }
@@ -50501,10 +50618,10 @@ ${textParts.join("\n")}` : "\n(no text content)";
           for (const s of shapes) {
             if (s.text !== void 0 && s.text.trim() === "") {
               issues.push({
-                check: "empty_text",
+                type: "empty_text",
                 severity: "warning",
-                shapes: [s.name],
-                message: `"${s.name}" has an empty text frame`
+                shapeIds: [s.id],
+                description: `"${s.name}" has an empty text frame`
               });
             }
           }
@@ -50513,10 +50630,22 @@ ${textParts.join("\n")}` : "\n(no text content)";
           for (const s of shapes) {
             if (s.width < 10 || s.height < 10) {
               issues.push({
-                check: "tiny_shapes",
+                type: "tiny_shapes",
                 severity: "warning",
-                shapes: [s.name],
-                message: `"${s.name}" is very small (${s.width.toFixed(1)} x ${s.height.toFixed(1)} pt)`
+                shapeIds: [s.id],
+                description: `"${s.name}" is very small (${s.width.toFixed(1)} x ${s.height.toFixed(1)} pt)`
+              });
+            }
+          }
+        }
+        if (enabledChecks.includes("unused_placeholder")) {
+          for (const s of shapes) {
+            if (s.isPlaceholder && !s.hasText) {
+              issues.push({
+                type: "unused_placeholder",
+                severity: "warning",
+                shapeIds: [s.id],
+                description: `"${s.name}" is an unused placeholder \u2014 delete it or fill it with content`
               });
             }
           }
@@ -50684,6 +50813,293 @@ ${textParts.join("\n")}` : "\n(no text content)";
     }
   );
   server.tool(
+    "search_text",
+    "Search for text across all slides (or a slide range) in the presentation \u2014 like grep for slides. Searches shape text, table cells, and speaker notes. Returns matching shapes with context at the chosen level. Case-insensitive substring by default; supports regex.",
+    {
+      query: external_exports3.string().describe("Text to search for. Plain substring by default, or a regex pattern when regex=true."),
+      slideRange: external_exports3.string().optional().describe('Optional slide range to search, e.g. "0-4" or "2-7". Zero-based. Omit to search all slides.'),
+      caseSensitive: external_exports3.boolean().optional().describe("Case-sensitive search. Default: false."),
+      regex: external_exports3.boolean().optional().describe("Treat query as a regular expression. Default: false (plain substring)."),
+      context: external_exports3.enum(["shape", "slide", "none"]).optional().describe(
+        'Result detail level. "shape" (default): matching shapes with text. "slide": all shapes on matching slides with matched markers. "none": just matching slide indices.'
+      ),
+      includeNotes: external_exports3.boolean().optional().describe("Search speaker notes in addition to slide content. Default: true."),
+      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
+    },
+    async ({ query, slideRange, caseSensitive, regex, context: contextLevel, includeNotes, presentationId }) => {
+      try {
+        const cs = caseSensitive === true;
+        const useRegex = regex === true;
+        const ctxLevel = contextLevel ?? "shape";
+        const searchNotes = includeNotes !== false;
+        const escapedQuery = JSON.stringify(query);
+        const code = `
+          var caseSensitive = ${cs};
+          var useRegex = ${useRegex};
+          var query = ${escapedQuery};
+          var ctxLevel = ${JSON.stringify(ctxLevel)};
+          var searchNotes = ${searchNotes};
+          var slideRangeStr = ${slideRange ? JSON.stringify(slideRange) : "null"};
+
+          function testMatch(text) {
+            if (useRegex) {
+              var flags = caseSensitive ? "" : "i";
+              var re = new RegExp(query, flags);
+              return re.test(text);
+            }
+            var a = caseSensitive ? text : text.toLowerCase();
+            var b = caseSensitive ? query : query.toLowerCase();
+            return a.indexOf(b) !== -1;
+          }
+
+          function extractShapeTexts(shapes) {
+            var results = [];
+            for (var j = 0; j < shapes.items.length; j++) {
+              var shape = shapes.items[j];
+              var texts = [];
+              try {
+                shape.textFrame.load("textRange");
+                try { shape.textFrame.textRange.load("text"); } catch(e) {}
+              } catch (e) {}
+              try {
+                if (shape.type === "Table") {
+                  shape.table.load("rowCount,columnCount");
+                }
+              } catch (e) {}
+            }
+            return shapes;
+          }
+
+          var slides = context.presentation.slides;
+          slides.load("items");
+          await context.sync();
+          var total = slides.items.length;
+          var startIdx = 0;
+          var endIdx = total - 1;
+          if (slideRangeStr) {
+            var parts = slideRangeStr.split("-");
+            startIdx = parseInt(parts[0], 10);
+            if (parts.length > 1) endIdx = parseInt(parts[1], 10);
+            else endIdx = startIdx;
+            if (startIdx < 0) startIdx = 0;
+            if (endIdx >= total) endIdx = total - 1;
+          }
+
+          var slideResults = [];
+          for (var si = startIdx; si <= endIdx; si++) {
+            var slide = slides.items[si];
+            slide.shapes.load("items");
+            await context.sync();
+
+            var shapeEntries = [];
+            var slideHasMatch = false;
+
+            for (var j = 0; j < slide.shapes.items.length; j++) {
+              var shape = slide.shapes.items[j];
+              var shapeId = String(shape.id);
+              var shapeName = shape.name;
+              var shapeType = shape.type;
+              var texts = [];
+
+              try {
+                shape.textFrame.load("textRange");
+                await context.sync();
+                var t = shape.textFrame.textRange.text;
+                if (t) texts.push({ source: "shape", text: t });
+              } catch (e) {}
+
+              if (shapeType === "Table") {
+                try {
+                  shape.table.load("rowCount,columnCount");
+                  await context.sync();
+                  var rc = shape.table.rowCount;
+                  var cc = shape.table.columnCount;
+                  for (var r = 0; r < rc; r++) {
+                    for (var c = 0; c < cc; c++) {
+                      try {
+                        var cell = shape.table.getCell(r, c);
+                        cell.body.load("text");
+                        await context.sync();
+                        if (cell.body.text) texts.push({ source: "tableCell", text: cell.body.text, row: r, col: c });
+                      } catch (e2) {}
+                    }
+                  }
+                } catch (e) {}
+              }
+
+              var matched = false;
+              for (var ti = 0; ti < texts.length; ti++) {
+                if (testMatch(texts[ti].text)) { matched = true; break; }
+              }
+
+              if (matched) slideHasMatch = true;
+
+              shapeEntries.push({
+                shapeId: shapeId,
+                shapeName: shapeName,
+                shapeType: shapeType,
+                matched: matched,
+                texts: texts
+              });
+            }
+
+            var noteText = null;
+            var noteMatched = false;
+            if (searchNotes) {
+              try {
+                var ns = slide.notesSlide;
+                ns.shapes.load("items");
+                await context.sync();
+                for (var ni = 0; ni < ns.shapes.items.length; ni++) {
+                  try {
+                    ns.shapes.items[ni].textFrame.load("textRange");
+                    await context.sync();
+                    var nt = ns.shapes.items[ni].textFrame.textRange.text;
+                    if (nt && nt.trim()) {
+                      noteText = (noteText || "") + nt;
+                    }
+                  } catch (e) {}
+                }
+                if (noteText && testMatch(noteText)) {
+                  noteMatched = true;
+                  slideHasMatch = true;
+                }
+              } catch (e) {}
+            }
+
+            if (slideHasMatch) {
+              if (ctxLevel === "none") {
+                slideResults.push(si);
+              } else if (ctxLevel === "slide") {
+                var entry = { slideIndex: si, shapes: [] };
+                for (var k = 0; k < shapeEntries.length; k++) {
+                  var se = shapeEntries[k];
+                  var shapeInfo = {
+                    shapeId: se.shapeId,
+                    shapeName: se.shapeName,
+                    matched: se.matched
+                  };
+                  for (var ti2 = 0; ti2 < se.texts.length; ti2++) {
+                    var tx = se.texts[ti2];
+                    if (tx.source === "shape") shapeInfo.text = tx.text;
+                    else if (tx.source === "tableCell") {
+                      if (!shapeInfo.tableCells) shapeInfo.tableCells = [];
+                      shapeInfo.tableCells.push({ row: tx.row, col: tx.col, text: tx.text, matched: testMatch(tx.text) });
+                    }
+                  }
+                  entry.shapes.push(shapeInfo);
+                }
+                if (noteText) entry.notes = { text: noteText, matched: noteMatched };
+                slideResults.push(entry);
+              } else {
+                for (var k2 = 0; k2 < shapeEntries.length; k2++) {
+                  var se2 = shapeEntries[k2];
+                  if (!se2.matched) continue;
+                  for (var ti3 = 0; ti3 < se2.texts.length; ti3++) {
+                    var tx2 = se2.texts[ti3];
+                    if (!testMatch(tx2.text)) continue;
+                    var m = { slideIndex: si, shapeId: se2.shapeId, shapeName: se2.shapeName, source: tx2.source, text: tx2.text };
+                    if (tx2.source === "tableCell") { m.row = tx2.row; m.col = tx2.col; }
+                    slideResults.push(m);
+                  }
+                }
+                if (noteMatched) {
+                  slideResults.push({ slideIndex: si, source: "note", text: noteText });
+                }
+              }
+            }
+          }
+
+          var result = { query: query, caseSensitive: caseSensitive, regex: useRegex, totalSlides: total };
+          if (ctxLevel === "none") {
+            result.matchingSlides = slideResults;
+          } else {
+            result.matches = slideResults;
+          }
+          return result;
+        `;
+        const target = pool2.resolveTarget(presentationId);
+        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
+        const text = JSON.stringify(result, null, 2) + (warning ?? "");
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+  server.tool(
+    "format_shapes",
+    "Apply formatting to multiple shapes on a slide in one call. Generates Office.js code internally. Use for fill color, font bold/italic/size/color/name. Cannot set corner radius or borders (use edit_slide_xml code mode for those).",
+    {
+      slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
+      shapes: external_exports3.array(
+        external_exports3.object({
+          id: external_exports3.string().describe("Shape ID from inspect_slide or scan_slide"),
+          fill: external_exports3.string().optional().describe('Fill color as hex without # (e.g., "1A1A1E")'),
+          font: external_exports3.object({
+            bold: external_exports3.boolean().optional(),
+            italic: external_exports3.boolean().optional(),
+            size: external_exports3.number().optional().describe("Font size in points"),
+            color: external_exports3.string().optional().describe('Font color as hex without # (e.g., "FFFFFF")'),
+            name: external_exports3.string().optional().describe('Font name (e.g., "Calibri")')
+          }).optional()
+        })
+      ).min(1).describe("Shapes to format with their properties"),
+      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
+    },
+    async ({ slideIndex, shapes, presentationId }) => {
+      try {
+        const target = pool2.resolveTarget(presentationId);
+        const shapeOps = shapes.map((s) => {
+          const lines = [];
+          lines.push(`  var s = shapeMap["${s.id}"];`);
+          lines.push(
+            `  if (!s) throw new Error("Shape " + ${JSON.stringify(s.id)} + " not found on slide ${slideIndex}");`
+          );
+          if (s.fill) {
+            lines.push(`  s.fill.setSolidColor("${s.fill}");`);
+          }
+          if (s.font) {
+            lines.push(`  var tf = s.getTextFrameOrNullObject();`);
+            lines.push(`  await context.sync();`);
+            lines.push(`  if (!tf.isNullObject) {`);
+            lines.push(`    var tr = tf.textRange;`);
+            if (s.font.bold !== void 0) lines.push(`    tr.font.bold = ${s.font.bold};`);
+            if (s.font.italic !== void 0) lines.push(`    tr.font.italic = ${s.font.italic};`);
+            if (s.font.size !== void 0) lines.push(`    tr.font.size = ${s.font.size};`);
+            if (s.font.color !== void 0) lines.push(`    tr.font.color = "${s.font.color}";`);
+            if (s.font.name !== void 0) lines.push(`    tr.font.name = "${s.font.name}";`);
+            lines.push(`  }`);
+          }
+          return lines.join("\n");
+        }).join("\n");
+        const code = `
+var slides = context.presentation.slides;
+slides.load("items");
+await context.sync();
+var slide = slides.items[${slideIndex}];
+slide.shapes.load("items");
+await context.sync();
+var shapeMap = {};
+for (var i = 0; i < slide.shapes.items.length; i++) {
+  shapeMap[slide.shapes.items[i].id] = slide.shapes.items[i];
+}
+${shapeOps}
+await context.sync();
+return { success: true, shapesFormatted: ${shapes.length} };`;
+        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
+        const text = JSON.stringify(result ?? { success: true }, null, 2) + (warning ?? "");
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+  server.tool(
     "execute_officejs",
     "Execute arbitrary Office.js code inside the live PowerPoint presentation. The code runs inside PowerPoint.run(async (context) => { ... }) with 'context' available as a variable. Use 'await context.sync()' after loading properties. Return a value to get it back as the tool result. For positioning, all values are in points (1 point = 1/72 inch). Common operations: add shapes, set text, change colors, add/delete slides.",
     {
@@ -50706,8 +51122,8 @@ ${textParts.join("\n")}` : "\n(no text content)";
     }
   );
   server.tool(
-    "search_icons",
-    'Search Microsoft Fluent UI icon library. Returns matching icons with IDs for use with insert_icon. Prefer mono (_M) variants for professional decks. Retry with synonyms if no good matches (e.g. "innovation" \u2192 "lightbulb", "security" \u2192 "shield").',
+    "search_fluent_icons",
+    'Search Microsoft Fluent UI icon library. Returns matching icons with SVG URLs for use with insert_image. Prefer mono (_M) variants for professional decks. Retry with synonyms if no good matches (e.g. "innovation" \u2192 "lightbulb", "security" \u2192 "shield").',
     {
       query: external_exports3.string().describe('Search query (e.g. "warning", "arrow down", "lightbulb")'),
       top: external_exports3.number().int().min(1).max(50).optional().describe("Max results to return (default 10)"),
@@ -50723,62 +51139,58 @@ ${textParts.join("\n")}` : "\n(no text content)";
       }
     }
   );
-  server.tool(
-    "insert_icon",
-    "Insert a Fluent UI icon onto a slide. Fetches SVG from CDN, optionally recolors it, and inserts via Office.js. Use search_icons first to find the icon ID. Pass color as hex to tint mono icons.",
-    {
-      iconId: external_exports3.string().describe('Icon ID from search_icons (e.g. "Icons_Warning_M" for mono, "Icons_Warning" for filled)'),
-      slideIndex: external_exports3.number().int().min(0).optional().describe("Zero-based slide index. If omitted, inserts on the currently active slide."),
-      x: external_exports3.number().optional().describe("Horizontal position in points (1 point = 1/72 inch)"),
-      y: external_exports3.number().optional().describe("Vertical position in points"),
-      width: external_exports3.number().optional().describe("Icon width in points (default 72)"),
-      height: external_exports3.number().optional().describe("Icon height in points (default 72)"),
-      color: external_exports3.string().optional().describe('Hex color to tint the icon (e.g. "#FF5733"). Works best with mono (_M) icons.'),
-      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
-    },
-    async ({ iconId, slideIndex, x, y, width, height, color, presentationId }) => {
-      try {
-        const base64Data = await fetchIconSvg(iconId, color);
-        const optionsParts = ["coercionType: Office.CoercionType.Image"];
-        if (x !== void 0) optionsParts.push(`imageLeft: ${x}`);
-        if (y !== void 0) optionsParts.push(`imageTop: ${y}`);
-        if (width !== void 0) optionsParts.push(`imageWidth: ${width}`);
-        if (height !== void 0) optionsParts.push(`imageHeight: ${height}`);
-        const optionsStr = `{ ${optionsParts.join(", ")} }`;
-        const insertCall = `Office.context.document.setSelectedDataAsync("${base64Data}", ${optionsStr}, function(result) {
-        if (result.status === Office.AsyncResultStatus.Succeeded) {
-          resolve({ success: true });
-        } else {
-          reject(new Error(result.error.message));
-        }
-      });`;
-        let code;
-        if (slideIndex !== void 0) {
-          code = `return new Promise(function(resolve, reject) {
-      Office.context.document.goToByIdAsync(${slideIndex + 1}, Office.GoToType.Index, function(navResult) {
-        if (navResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(new Error("Navigation failed: " + navResult.error.message));
-          return;
-        }
-        ${insertCall}
-      });
-    });`;
-        } else {
-          code = `return new Promise(function(resolve, reject) {
-      ${insertCall}
-    });`;
-        }
-        const target = pool2.resolveTarget(presentationId);
-        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
-        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
-        const text = JSON.stringify(result ?? { success: true, iconId }, null, 2) + (warning ?? "");
-        return { content: [{ type: "text", text }] };
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
-      }
+}
+
+// server/version-check.ts
+async function checkForUpdate(options) {
+  const {
+    currentVersion,
+    packageName = "powerpoint-bridge",
+    registryUrl = "https://registry.npmjs.org",
+    timeoutMs = 3e3
+  } = options;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(`${registryUrl}/${packageName}/latest`, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" }
+    });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const latest = data.version;
+    if (!latest) return null;
+    return {
+      latest,
+      current: currentVersion,
+      updateAvailable: isNewer(latest, currentVersion)
+    };
+  } catch {
+    return null;
+  }
+}
+function isNewer(latest, current) {
+  const parse3 = (v) => v.replace(/^v/, "").split("-")[0].split(".").map(Number);
+  const [lMajor = 0, lMinor = 0, lPatch = 0] = parse3(latest);
+  const [cMajor = 0, cMinor = 0, cPatch = 0] = parse3(current);
+  if (lMajor !== cMajor) return lMajor > cMajor;
+  if (lMinor !== cMinor) return lMinor > cMinor;
+  return lPatch > cPatch;
+}
+function runVersionCheck(currentVersion) {
+  if (process.env.BRIDGE_NO_UPDATE_CHECK === "1") return;
+  if (process.argv.includes("--no-update-check")) return;
+  checkForUpdate({ currentVersion }).then((result) => {
+    if (result?.updateAvailable) {
+      console.error(
+        `
+  Update available: v${result.current} \u2192 v${result.latest}
+  Run "npm update -g powerpoint-bridge" to upgrade
+`
+      );
     }
-  );
+  });
 }
 
 // server/index.ts
@@ -51131,6 +51543,11 @@ if (stdioActive) {
   stdioMcpServer.connect(stdioTransport).then(() => {
     console.error("MCP STDIO transport running");
   });
+}
+try {
+  const pkg = JSON.parse((0, import_node_fs3.readFileSync)((0, import_node_path3.resolve)(PROJECT_ROOT, "package.json"), "utf8"));
+  runVersionCheck(pkg.version);
+} catch {
 }
 var activeInterfaces = [
   stdioActive && "STDIO",

--- a/scripts/build-icon-index.ts
+++ b/scripts/build-icon-index.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * Fetches icon names from microsoft/fluentui-system-icons GitHub repo
+ * and generates server/icon-index.json for search_icons/insert_icon tools.
+ *
+ * Usage: npx tsx scripts/build-icon-index.ts
+ */
+
+import { writeFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const OUTPUT_PATH = join(__dirname, '..', 'server', 'icon-index.json')
+
+const GITHUB_API = 'https://api.github.com'
+const REPO = 'microsoft/fluentui-system-icons'
+
+interface GitTreeEntry {
+  path: string
+  type: 'tree' | 'blob'
+  sha: string
+}
+
+interface IconEntry {
+  /** Display name, matches repo directory (e.g. "Warning", "Add Circle") */
+  n: string
+  /** Space-separated lowercase keywords for search */
+  k: string
+}
+
+function generateKeywords(name: string): string {
+  // Split PascalCase and spaces into individual words
+  const words = name
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .split(/[\s_]+/)
+    .map((w) => w.toLowerCase())
+    .filter((w) => w.length > 0)
+  return [...new Set(words)].join(' ')
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'powerpoint-bridge-icon-index-builder',
+  }
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
+  const resp = await fetch(url, { headers })
+  if (!resp.ok) {
+    throw new Error(`GitHub API error: ${resp.status} ${resp.statusText} for ${url}`)
+  }
+  return resp.json()
+}
+
+async function main() {
+  console.log('Fetching repo tree...')
+
+  // Get root tree to find assets directory SHA
+  const rootTree = (await fetchJson(`${GITHUB_API}/repos/${REPO}/git/trees/main`)) as {
+    tree: GitTreeEntry[]
+  }
+  const assetsEntry = rootTree.tree.find((e) => e.path === 'assets' && e.type === 'tree')
+  if (!assetsEntry) {
+    throw new Error('Could not find assets directory in repo tree')
+  }
+
+  // Get all icon directories from assets tree
+  console.log('Fetching assets tree...')
+  const assetsTree = (await fetchJson(`${GITHUB_API}/repos/${REPO}/git/trees/${assetsEntry.sha}`)) as {
+    tree: GitTreeEntry[]
+    truncated: boolean
+  }
+
+  if (assetsTree.truncated) {
+    console.warn('Warning: assets tree was truncated, some icons may be missing')
+  }
+
+  const icons: IconEntry[] = assetsTree.tree
+    .filter((e) => e.type === 'tree')
+    .map((e) => ({
+      n: e.path,
+      k: generateKeywords(e.path),
+    }))
+    .sort((a, b) => a.n.localeCompare(b.n))
+
+  console.log(`Found ${icons.length} icons`)
+
+  writeFileSync(OUTPUT_PATH, JSON.stringify(icons))
+  console.log(`Written to ${OUTPUT_PATH}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/server/icons.test.ts
+++ b/server/icons.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildIndexFromManifest,
+  fetchIconSvg,
+  nameToId,
+  parseIconId,
+  resetIndex,
+  resetSvgCache,
+  searchIcons,
+} from './icons.ts'
+
+// Mock fs so loadStaticIndex() fails and we control the index via buildIndexFromManifest
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(() => {
+    throw new Error('no static index')
+  }),
+  existsSync: vi.fn(() => false),
+  writeFileSync: vi.fn(),
+}))
+
+// Sample manifest matching fluentui-system-icons format
+const SAMPLE_MANIFEST: Record<string, number> = {
+  ic_fluent_warning_16_regular: 0xe001,
+  ic_fluent_warning_20_regular: 0xe002,
+  ic_fluent_warning_24_regular: 0xe003,
+  ic_fluent_arrow_down_20_regular: 0xe004,
+  ic_fluent_arrow_down_24_regular: 0xe005,
+  ic_fluent_checkmark_circle_20_regular: 0xe006,
+  ic_fluent_checkmark_circle_24_regular: 0xe007,
+  ic_fluent_lightbulb_20_regular: 0xe008,
+  ic_fluent_lightbulb_24_regular: 0xe009,
+  ic_fluent_shield_20_regular: 0xe00a,
+  ic_fluent_shield_24_regular: 0xe00b,
+  ic_fluent_rocket_20_regular: 0xe00c,
+  ic_fluent_rocket_24_regular: 0xe00d,
+  ic_fluent_heart_20_regular: 0xe00e,
+  ic_fluent_heart_24_regular: 0xe00f,
+  ic_fluent_star_20_regular: 0xe010,
+  ic_fluent_star_24_regular: 0xe011,
+  ic_fluent_home_20_regular: 0xe012,
+  ic_fluent_home_24_regular: 0xe013,
+  ic_fluent_settings_20_regular: 0xe014,
+  ic_fluent_settings_24_regular: 0xe015,
+}
+
+// Mock global fetch for both manifest and SVG fetching
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+describe('icons', () => {
+  afterEach(() => {
+    resetIndex()
+    resetSvgCache()
+    mockFetch.mockReset()
+  })
+
+  describe('buildIndexFromManifest', () => {
+    it('extracts unique icon names from font manifest', () => {
+      const index = buildIndexFromManifest(SAMPLE_MANIFEST)
+      const names = index.map((e) => e.name)
+      expect(names).toEqual([
+        'Arrow Down',
+        'Checkmark Circle',
+        'Heart',
+        'Home',
+        'Lightbulb',
+        'Rocket',
+        'Settings',
+        'Shield',
+        'Star',
+        'Warning',
+      ])
+    })
+
+    it('deduplicates entries with different sizes', () => {
+      const index = buildIndexFromManifest(SAMPLE_MANIFEST)
+      // Warning has 3 size variants but should appear once
+      const warningEntries = index.filter((e) => e.name === 'Warning')
+      expect(warningEntries).toHaveLength(1)
+    })
+
+    it('generates correct snake names and keywords', () => {
+      const index = buildIndexFromManifest(SAMPLE_MANIFEST)
+      const checkmark = index.find((e) => e.name === 'Checkmark Circle')
+      expect(checkmark?.snakeName).toBe('checkmark_circle')
+      expect(checkmark?.keywords).toEqual(['checkmark', 'circle'])
+    })
+
+    it('ignores non-regular entries', () => {
+      const manifest = {
+        ...SAMPLE_MANIFEST,
+        ic_fluent_alert_24_filled: 0xf001, // filled, not regular — should be ignored
+        some_other_key: 0xf002, // doesn't match pattern
+      }
+      const index = buildIndexFromManifest(manifest)
+      const names = index.map((e) => e.name)
+      expect(names).not.toContain('Alert')
+    })
+  })
+
+  describe('nameToId', () => {
+    it('creates filled icon ID', () => {
+      expect(nameToId('Warning', false)).toBe('Icons_Warning')
+    })
+
+    it('creates mono icon ID with _M suffix', () => {
+      expect(nameToId('Warning', true)).toBe('Icons_Warning_M')
+    })
+
+    it('handles multi-word names', () => {
+      expect(nameToId('Arrow Down', false)).toBe('Icons_Arrow_Down')
+      expect(nameToId('Arrow Down', true)).toBe('Icons_Arrow_Down_M')
+    })
+  })
+
+  describe('parseIconId', () => {
+    it('parses filled icon ID', () => {
+      expect(parseIconId('Icons_Warning')).toEqual({
+        snakeName: 'warning',
+        isMono: false,
+      })
+    })
+
+    it('parses mono icon ID', () => {
+      expect(parseIconId('Icons_Warning_M')).toEqual({
+        snakeName: 'warning',
+        isMono: true,
+      })
+    })
+
+    it('handles multi-word icon IDs', () => {
+      expect(parseIconId('Icons_Arrow_Down')).toEqual({
+        snakeName: 'arrow_down',
+        isMono: false,
+      })
+      expect(parseIconId('Icons_Arrow_Down_M')).toEqual({
+        snakeName: 'arrow_down',
+        isMono: true,
+      })
+    })
+  })
+
+  describe('searchIcons', () => {
+    function setupManifestFetch() {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => SAMPLE_MANIFEST,
+      })
+    }
+
+    it('returns matching icons sorted by score', async () => {
+      setupManifestFetch()
+      const results = await searchIcons('warning', 5)
+      expect(results.length).toBeGreaterThan(0)
+      expect(results[0].id).toContain('Warning')
+    })
+
+    it('returns both mono and filled variants by default', async () => {
+      setupManifestFetch()
+      const results = await searchIcons('warning', 10)
+      const monoResult = results.find((r) => r.isMono)
+      const filledResult = results.find((r) => !r.isMono)
+      expect(monoResult).toBeDefined()
+      expect(filledResult).toBeDefined()
+    })
+
+    it('filters to regular style only', async () => {
+      setupManifestFetch()
+      const results = await searchIcons('warning', 10, 'regular')
+      for (const r of results) {
+        expect(r.isMono).toBe(true)
+      }
+    })
+
+    it('filters to filled style only', async () => {
+      setupManifestFetch()
+      const results = await searchIcons('warning', 10, 'filled')
+      for (const r of results) {
+        expect(r.isMono).toBe(false)
+      }
+    })
+
+    it('respects top limit', async () => {
+      setupManifestFetch()
+      const results = await searchIcons('a', 3)
+      expect(results.length).toBeLessThanOrEqual(3)
+    })
+
+    it('returns empty for no match', async () => {
+      setupManifestFetch()
+      const results = await searchIcons('xyznonexistent', 5)
+      expect(results).toEqual([])
+    })
+
+    it('returns empty for empty query', async () => {
+      setupManifestFetch()
+      const results = await searchIcons('', 5)
+      expect(results).toEqual([])
+    })
+
+    it('includes contentTier and searchScore', async () => {
+      setupManifestFetch()
+      const results = await searchIcons('heart', 2)
+      expect(results[0].contentTier).toBe('free')
+      expect(results[0].searchScore).toBeGreaterThan(0)
+    })
+
+    it('caches index after first load', async () => {
+      setupManifestFetch()
+      await searchIcons('warning', 1)
+      // Second call should not trigger another fetch
+      const results = await searchIcons('star', 1)
+      expect(results.length).toBeGreaterThan(0)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('fetchIconSvg', () => {
+    const SAMPLE_SVG = '<svg><path fill="#212121" d="M10 10"/></svg>'
+
+    it('fetches SVG and returns base64', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: async () => SAMPLE_SVG,
+      })
+      const result = await fetchIconSvg('Icons_Warning_M')
+      const decoded = Buffer.from(result, 'base64').toString('utf-8')
+      expect(decoded).toContain('<svg>')
+    })
+
+    it('recolors SVG when color is provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: async () => SAMPLE_SVG,
+      })
+      const result = await fetchIconSvg('Icons_Warning_M', '#FF0000')
+      const decoded = Buffer.from(result, 'base64').toString('utf-8')
+      expect(decoded).toContain('fill:#FF0000')
+      expect(decoded).toContain('class="icon-color"')
+    })
+
+    it('caches fetched SVGs', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: async () => SAMPLE_SVG,
+      })
+      await fetchIconSvg('Icons_Warning_M')
+      // Second call should use cache
+      await fetchIconSvg('Icons_Warning_M')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses different cache keys for mono vs filled', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, text: async () => '<svg>regular</svg>' })
+        .mockResolvedValueOnce({ ok: true, text: async () => '<svg>filled</svg>' })
+      await fetchIconSvg('Icons_Warning_M')
+      await fetchIconSvg('Icons_Warning')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws on fetch failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+      await expect(fetchIconSvg('Icons_Nonexistent_M')).rejects.toThrow('Failed to fetch icon SVG: 404')
+    })
+
+    it('constructs correct CDN URL for mono icons', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: async () => SAMPLE_SVG,
+      })
+      await fetchIconSvg('Icons_Warning_M')
+      const calledUrl = mockFetch.mock.calls[0][0] as string
+      expect(calledUrl).toContain('/Warning/SVG/ic_fluent_warning_24_regular.svg')
+    })
+
+    it('constructs correct CDN URL for filled icons', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: async () => SAMPLE_SVG,
+      })
+      await fetchIconSvg('Icons_Warning')
+      const calledUrl = mockFetch.mock.calls[0][0] as string
+      expect(calledUrl).toContain('/Warning/SVG/ic_fluent_warning_24_filled.svg')
+    })
+  })
+})

--- a/server/icons.test.ts
+++ b/server/icons.test.ts
@@ -198,11 +198,12 @@ describe('icons', () => {
       expect(results).toEqual([])
     })
 
-    it('includes contentTier and searchScore', async () => {
+    it('includes contentTier, searchScore, and svgUrl', async () => {
       setupManifestFetch()
       const results = await searchIcons('heart', 2)
       expect(results[0].contentTier).toBe('free')
       expect(results[0].searchScore).toBeGreaterThan(0)
+      expect(results[0].svgUrl).toMatch(/^https:\/\/raw\.githubusercontent\.com\/microsoft\/fluentui-system-icons/)
     })
 
     it('caches index after first load', async () => {

--- a/server/icons.ts
+++ b/server/icons.ts
@@ -1,0 +1,299 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Compact index entry: name + space-separated keywords */
+interface RawIconEntry {
+  /** Display name matching repo directory (e.g. "Warning", "Add Circle") */
+  n: string
+  /** Space-separated lowercase keywords for search */
+  k: string
+}
+
+interface IconIndexEntry {
+  name: string
+  snakeName: string
+  keywords: string[]
+}
+
+export interface IconSearchResult {
+  id: string
+  description: string
+  isMono: boolean
+  contentTier: string
+  searchScore: number
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MANIFEST_URL =
+  'https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/fonts/FluentSystemIcons-Regular.json'
+
+const CDN_BASE = 'https://raw.githubusercontent.com/microsoft/fluentui-system-icons/main/assets'
+
+const DEFAULT_SIZE = 24
+
+// ---------------------------------------------------------------------------
+// Caches
+// ---------------------------------------------------------------------------
+
+let cachedIndex: IconIndexEntry[] | null = null
+const svgCache = new Map<string, string>()
+
+// ---------------------------------------------------------------------------
+// Name conversion helpers
+// ---------------------------------------------------------------------------
+
+function snakeToTitle(s: string): string {
+  return s
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+function titleToSnake(s: string): string {
+  return s.replace(/\s+/g, '_').toLowerCase()
+}
+
+/** Convert display name to our icon ID: "Warning" → "Icons_Warning" */
+export function nameToId(name: string, mono: boolean): string {
+  const base = `Icons_${name.replace(/\s+/g, '_')}`
+  return mono ? `${base}_M` : base
+}
+
+/** Parse icon ID back to snake name + mono flag */
+export function parseIconId(iconId: string): { snakeName: string; isMono: boolean } {
+  let id = iconId
+  let isMono = false
+  if (id.endsWith('_M')) {
+    isMono = true
+    id = id.slice(0, -2)
+  }
+  if (id.startsWith('Icons_')) {
+    id = id.slice(6)
+  }
+  return { snakeName: id.toLowerCase(), isMono }
+}
+
+// ---------------------------------------------------------------------------
+// Index loading
+// ---------------------------------------------------------------------------
+
+/** Build index from the font manifest JSON (keys are ic_fluent_{name}_{size}_regular) */
+export function buildIndexFromManifest(manifest: Record<string, unknown>): IconIndexEntry[] {
+  const seen = new Set<string>()
+  const entries: IconIndexEntry[] = []
+
+  for (const key of Object.keys(manifest)) {
+    const match = key.match(/^ic_fluent_(.+)_(\d+)_regular$/)
+    if (!match) continue
+    const snakeName = match[1]
+    if (seen.has(snakeName)) continue
+    seen.add(snakeName)
+
+    const name = snakeToTitle(snakeName)
+    entries.push({
+      name,
+      snakeName,
+      keywords: snakeName.split('_'),
+    })
+  }
+
+  return entries.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+/** Try loading static icon-index.json from disk */
+function loadStaticIndex(): IconIndexEntry[] | null {
+  try {
+    const dir = dirname(fileURLToPath(import.meta.url))
+    const raw = readFileSync(join(dir, 'icon-index.json'), 'utf-8')
+    const data: RawIconEntry[] = JSON.parse(raw)
+    return data.map((e) => ({
+      name: e.n,
+      snakeName: titleToSnake(e.n),
+      keywords: e.k.split(' '),
+    }))
+  } catch {
+    return null
+  }
+}
+
+/** Load or fetch the icon index. Caches in memory after first call. */
+export async function loadIndex(): Promise<IconIndexEntry[]> {
+  if (cachedIndex) return cachedIndex
+
+  // Try static JSON first
+  const staticIndex = loadStaticIndex()
+  if (staticIndex && staticIndex.length > 0) {
+    cachedIndex = staticIndex
+    return cachedIndex
+  }
+
+  // Fetch manifest from CDN
+  const resp = await fetch(MANIFEST_URL)
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch icon manifest: ${resp.status} ${resp.statusText}`)
+  }
+  const manifest = (await resp.json()) as Record<string, unknown>
+  cachedIndex = buildIndexFromManifest(manifest)
+  return cachedIndex
+}
+
+/** Reset cached index (for testing) */
+export function resetIndex(): void {
+  cachedIndex = null
+}
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+function scoreMatch(entry: IconIndexEntry, queryWords: string[]): number {
+  let score = 0
+  const nameLower = entry.name.toLowerCase()
+  const allWords = [nameLower, ...entry.keywords]
+
+  for (const qw of queryWords) {
+    // Exact keyword match
+    if (entry.keywords.includes(qw)) {
+      score += 10
+      continue
+    }
+    // Name contains query word
+    if (nameLower.includes(qw)) {
+      score += 8
+      continue
+    }
+    // Partial keyword match (keyword starts with query word)
+    if (entry.keywords.some((kw) => kw.startsWith(qw))) {
+      score += 5
+      continue
+    }
+    // Any word contains query word as substring
+    if (allWords.some((w) => w.includes(qw))) {
+      score += 3
+      continue
+    }
+    // No match for this query word — penalty
+    score -= 2
+  }
+
+  // Bonus for exact name match
+  const queryJoined = queryWords.join(' ')
+  if (nameLower === queryJoined) {
+    score += 20
+  }
+
+  return score
+}
+
+export async function searchIcons(query: string, top = 10, style?: 'regular' | 'filled'): Promise<IconSearchResult[]> {
+  const index = await loadIndex()
+  const queryWords = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+
+  if (queryWords.length === 0) return []
+
+  const scored = index
+    .map((entry) => ({ entry, score: scoreMatch(entry, queryWords) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, top)
+
+  const isMono = style === 'regular'
+  const isFilled = style === 'filled'
+
+  // If no style filter, return both variants for each match
+  if (!isMono && !isFilled) {
+    const results: IconSearchResult[] = []
+    for (const { entry, score } of scored) {
+      results.push({
+        id: nameToId(entry.name, true),
+        description: `${entry.name} (mono/outline)`,
+        isMono: true,
+        contentTier: 'free',
+        searchScore: score,
+      })
+      results.push({
+        id: nameToId(entry.name, false),
+        description: `${entry.name} (filled)`,
+        isMono: false,
+        contentTier: 'free',
+        searchScore: score,
+      })
+    }
+    return results.slice(0, top)
+  }
+
+  return scored.map(({ entry, score }) => ({
+    id: nameToId(entry.name, isMono),
+    description: `${entry.name} (${isMono ? 'mono/outline' : 'filled'})`,
+    isMono,
+    contentTier: 'free',
+    searchScore: score,
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// SVG fetch + recolor
+// ---------------------------------------------------------------------------
+
+function buildSvgUrl(snakeName: string, isMono: boolean): string {
+  const dirName = snakeToTitle(snakeName)
+  const style = isMono ? 'regular' : 'filled'
+  const fileName = `ic_fluent_${snakeName}_${DEFAULT_SIZE}_${style}.svg`
+  return `${CDN_BASE}/${encodeURIComponent(dirName)}/SVG/${fileName}`
+}
+
+function recolorSvg(svg: string, color: string): string {
+  // Inject a CSS style block after the opening <svg> tag to override all fills
+  const styleTag = `<style>.icon-color{fill:${color}}</style>`
+  let result = svg.replace(/(<svg[^>]*>)/, `$1${styleTag}`)
+  // Replace all fill attributes on path/circle/rect elements with class reference
+  result = result.replace(/(<(?:path|circle|rect|polygon|ellipse)[^>]*?)fill="[^"]*"/g, '$1class="icon-color"')
+  // For paths without fill attribute, add the class
+  result = result.replace(
+    /(<(?:path|circle|rect|polygon|ellipse)(?![^>]*class=)[^>]*?)(\/?>)/g,
+    '$1 class="icon-color"$2',
+  )
+  return result
+}
+
+/**
+ * Fetch an icon SVG by icon ID, optionally recolor it, and return as base64.
+ * Caches fetched SVGs in memory.
+ */
+export async function fetchIconSvg(iconId: string, color?: string): Promise<string> {
+  const { snakeName, isMono } = parseIconId(iconId)
+  const cacheKey = `${snakeName}:${isMono ? 'regular' : 'filled'}`
+
+  let svg = svgCache.get(cacheKey)
+  if (!svg) {
+    const url = buildSvgUrl(snakeName, isMono)
+    const resp = await fetch(url)
+    if (!resp.ok) {
+      throw new Error(`Failed to fetch icon SVG: ${resp.status} ${resp.statusText} (${url})`)
+    }
+    svg = await resp.text()
+    svgCache.set(cacheKey, svg)
+  }
+
+  if (color) {
+    svg = recolorSvg(svg, color)
+  }
+
+  return Buffer.from(svg).toString('base64')
+}
+
+/** Reset SVG cache (for testing) */
+export function resetSvgCache(): void {
+  svgCache.clear()
+}

--- a/server/icons.ts
+++ b/server/icons.ts
@@ -26,6 +26,7 @@ export interface IconSearchResult {
   isMono: boolean
   contentTier: string
   searchScore: number
+  svgUrl: string
 }
 
 // ---------------------------------------------------------------------------
@@ -221,6 +222,7 @@ export async function searchIcons(query: string, top = 10, style?: 'regular' | '
         isMono: true,
         contentTier: 'free',
         searchScore: score,
+        svgUrl: buildSvgUrl(entry.snakeName, true),
       })
       results.push({
         id: nameToId(entry.name, false),
@@ -228,6 +230,7 @@ export async function searchIcons(query: string, top = 10, style?: 'regular' | '
         isMono: false,
         contentTier: 'free',
         searchScore: score,
+        svgUrl: buildSvgUrl(entry.snakeName, false),
       })
     }
     return results.slice(0, top)
@@ -239,6 +242,7 @@ export async function searchIcons(query: string, top = 10, style?: 'regular' | '
     isMono,
     contentTier: 'free',
     searchScore: score,
+    svgUrl: buildSvgUrl(entry.snakeName, isMono),
   }))
 }
 
@@ -246,14 +250,14 @@ export async function searchIcons(query: string, top = 10, style?: 'regular' | '
 // SVG fetch + recolor
 // ---------------------------------------------------------------------------
 
-function buildSvgUrl(snakeName: string, isMono: boolean): string {
+export function buildSvgUrl(snakeName: string, isMono: boolean): string {
   const dirName = snakeToTitle(snakeName)
   const style = isMono ? 'regular' : 'filled'
   const fileName = `ic_fluent_${snakeName}_${DEFAULT_SIZE}_${style}.svg`
   return `${CDN_BASE}/${encodeURIComponent(dirName)}/SVG/${fileName}`
 }
 
-function recolorSvg(svg: string, color: string): string {
+export function recolorSvg(svg: string, color: string): string {
   // Inject a CSS style block after the opening <svg> tag to override all fills
   const styleTag = `<style>.icon-color{fill:${color}}</style>`
   let result = svg.replace(/(<svg[^>]*>)/, `$1${styleTag}`)

--- a/server/tools.test.ts
+++ b/server/tools.test.ts
@@ -81,7 +81,7 @@ describe('MCP Tools', () => {
     pool = new ConnectionPool(100)
   })
 
-  it('lists all 20 tools', async () => {
+  it('lists all 19 tools', async () => {
     const { client } = await setupMcpClient(pool)
     const result = await client.listTools()
     const names = result.tools.map((t) => t.name).sort()
@@ -95,7 +95,6 @@ describe('MCP Tools', () => {
       'execute_officejs',
       'format_shapes',
       'get_local_copy',
-      'insert_icon',
       'insert_image',
       'inspect_slide',
       'list_presentations',
@@ -106,7 +105,7 @@ describe('MCP Tools', () => {
       'read_slide_zip',
       'scan_slide',
       'screenshot_slide',
-      'search_icons',
+      'search_fluent_icons',
       'search_text',
       'verify_slides',
     ])

--- a/server/tools.test.ts
+++ b/server/tools.test.ts
@@ -95,6 +95,7 @@ describe('MCP Tools', () => {
       'execute_officejs',
       'format_shapes',
       'get_local_copy',
+      'insert_icon',
       'insert_image',
       'inspect_slide',
       'list_presentations',
@@ -105,6 +106,7 @@ describe('MCP Tools', () => {
       'read_slide_zip',
       'scan_slide',
       'screenshot_slide',
+      'search_icons',
       'search_text',
       'verify_slides',
     ])

--- a/server/tools.ts
+++ b/server/tools.ts
@@ -6,6 +6,7 @@ import { DOMParser } from '@xmldom/xmldom'
 import { z } from 'zod'
 import type { ConnectionPool } from './bridge.ts'
 import { buildChartRelationship, buildChartXml, buildGraphicFrame, resolveChartPosition } from './chart-builder.ts'
+import { fetchIconSvg, searchIcons } from './icons.ts'
 import {
   autoRegisterContentTypes,
   escapeXml,
@@ -1826,6 +1827,108 @@ return { success: true, shapesFormatted: ${shapes.length} };`
         const result = await pool.sendCommand('executeCode', { code }, target.ws)
         const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount())
         const text = JSON.stringify(result ?? { success: true }, null, 2) + (warning ?? '')
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
+      }
+    },
+  )
+
+  // --- Tool: search_icons ---
+  server.tool(
+    'search_icons',
+    'Search Microsoft Fluent UI icon library. Returns matching icons with IDs for use with insert_icon. Prefer mono (_M) variants for professional decks. Retry with synonyms if no good matches (e.g. "innovation" → "lightbulb", "security" → "shield").',
+    {
+      query: z.string().describe('Search query (e.g. "warning", "arrow down", "lightbulb")'),
+      top: z.number().int().min(1).max(50).optional().describe('Max results to return (default 10)'),
+      style: z
+        .enum(['regular', 'filled'])
+        .optional()
+        .describe('Filter by style: "regular" for mono/outline icons, "filled" for solid icons. Omit for both.'),
+    },
+    async ({ query, top, style }) => {
+      try {
+        const results = await searchIcons(query, top ?? 10, style)
+        return { content: [{ type: 'text' as const, text: JSON.stringify(results, null, 2) }] }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
+      }
+    },
+  )
+
+  // --- Tool: insert_icon ---
+  server.tool(
+    'insert_icon',
+    'Insert a Fluent UI icon onto a slide. Fetches SVG from CDN, optionally recolors it, and inserts via Office.js. Use search_icons first to find the icon ID. Pass color as hex to tint mono icons.',
+    {
+      iconId: z
+        .string()
+        .describe('Icon ID from search_icons (e.g. "Icons_Warning_M" for mono, "Icons_Warning" for filled)'),
+      slideIndex: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Zero-based slide index. If omitted, inserts on the currently active slide.'),
+      x: z.number().optional().describe('Horizontal position in points (1 point = 1/72 inch)'),
+      y: z.number().optional().describe('Vertical position in points'),
+      width: z.number().optional().describe('Icon width in points (default 72)'),
+      height: z.number().optional().describe('Icon height in points (default 72)'),
+      color: z
+        .string()
+        .optional()
+        .describe('Hex color to tint the icon (e.g. "#FF5733"). Works best with mono (_M) icons.'),
+      presentationId: z
+        .string()
+        .optional()
+        .describe('Target presentation ID from list_presentations. Optional when only one presentation is connected.'),
+    },
+    async ({ iconId, slideIndex, x, y, width, height, color, presentationId }) => {
+      try {
+        // Step 1: Fetch and recolor SVG
+        const base64Data = await fetchIconSvg(iconId, color)
+
+        // Step 2: Build options object string with only provided params
+        const optionsParts: string[] = ['coercionType: Office.CoercionType.Image']
+        if (x !== undefined) optionsParts.push(`imageLeft: ${x}`)
+        if (y !== undefined) optionsParts.push(`imageTop: ${y}`)
+        if (width !== undefined) optionsParts.push(`imageWidth: ${width}`)
+        if (height !== undefined) optionsParts.push(`imageHeight: ${height}`)
+        const optionsStr = `{ ${optionsParts.join(', ')} }`
+
+        // Step 3: Build the setSelectedDataAsync call
+        const insertCall = `Office.context.document.setSelectedDataAsync("${base64Data}", ${optionsStr}, function(result) {
+        if (result.status === Office.AsyncResultStatus.Succeeded) {
+          resolve({ success: true });
+        } else {
+          reject(new Error(result.error.message));
+        }
+      });`
+
+        // Step 4: Wrap with goToByIdAsync if slideIndex is provided
+        let code: string
+        if (slideIndex !== undefined) {
+          code = `return new Promise(function(resolve, reject) {
+      Office.context.document.goToByIdAsync(${slideIndex + 1}, Office.GoToType.Index, function(navResult) {
+        if (navResult.status !== Office.AsyncResultStatus.Succeeded) {
+          reject(new Error("Navigation failed: " + navResult.error.message));
+          return;
+        }
+        ${insertCall}
+      });
+    });`
+        } else {
+          code = `return new Promise(function(resolve, reject) {
+      ${insertCall}
+    });`
+        }
+
+        const target = pool.resolveTarget(presentationId)
+        const result = await pool.sendCommand('executeCode', { code }, target.ws)
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount())
+        const text = JSON.stringify(result ?? { success: true, iconId }, null, 2) + (warning ?? '')
         return { content: [{ type: 'text' as const, text }] }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)

--- a/server/tools.ts
+++ b/server/tools.ts
@@ -6,7 +6,7 @@ import { DOMParser } from '@xmldom/xmldom'
 import { z } from 'zod'
 import type { ConnectionPool } from './bridge.ts'
 import { buildChartRelationship, buildChartXml, buildGraphicFrame, resolveChartPosition } from './chart-builder.ts'
-import { fetchIconSvg, searchIcons } from './icons.ts'
+import { recolorSvg, searchIcons } from './icons.ts'
 import {
   autoRegisterContentTypes,
   escapeXml,
@@ -509,12 +509,18 @@ export function registerTools(
       top: z.number().optional().describe('Vertical position in points'),
       width: z.number().optional().describe('Image width in points'),
       height: z.number().optional().describe('Image height in points'),
+      color: z
+        .string()
+        .optional()
+        .describe(
+          'Hex color to tint SVG images (e.g. "#FF5733"). Only applies to SVG sources. Works best with mono/outline icons.',
+        ),
       presentationId: z
         .string()
         .optional()
         .describe('Target presentation ID from list_presentations. Optional when only one presentation is connected.'),
     },
-    async ({ source, sourceType, slideIndex, left, top, width, height, presentationId }) => {
+    async ({ source, sourceType, slideIndex, left, top, width, height, color, presentationId }) => {
       try {
         // Step 1: Resolve image to base64
         let base64Data: string
@@ -529,6 +535,16 @@ export function registerTools(
           base64Data = Buffer.from(buf).toString('base64')
         } else {
           base64Data = source
+        }
+
+        // Step 1b: Recolor SVG if color is provided
+        if (color) {
+          const svg = Buffer.from(base64Data, 'base64').toString('utf-8')
+          if (svg.trimStart().startsWith('<svg') || svg.trimStart().startsWith('<?xml')) {
+            base64Data = Buffer.from(recolorSvg(svg, color)).toString('base64')
+          } else {
+            throw new Error('color parameter only works with SVG images, but the source is not SVG')
+          }
         }
 
         // Step 2: Build options object string with only provided params
@@ -1835,10 +1851,10 @@ return { success: true, shapesFormatted: ${shapes.length} };`
     },
   )
 
-  // --- Tool: search_icons ---
+  // --- Tool: search_fluent_icons ---
   server.tool(
-    'search_icons',
-    'Search Microsoft Fluent UI icon library. Returns matching icons with IDs for use with insert_icon. Prefer mono (_M) variants for professional decks. Retry with synonyms if no good matches (e.g. "innovation" → "lightbulb", "security" → "shield").',
+    'search_fluent_icons',
+    'Search Microsoft Fluent UI icon library. Returns matching icons with SVG URLs for use with insert_image. Prefer mono (_M) variants for professional decks. Retry with synonyms if no good matches (e.g. "innovation" → "lightbulb", "security" → "shield").',
     {
       query: z.string().describe('Search query (e.g. "warning", "arrow down", "lightbulb")'),
       top: z.number().int().min(1).max(50).optional().describe('Max results to return (default 10)'),
@@ -1851,85 +1867,6 @@ return { success: true, shapesFormatted: ${shapes.length} };`
       try {
         const results = await searchIcons(query, top ?? 10, style)
         return { content: [{ type: 'text' as const, text: JSON.stringify(results, null, 2) }] }
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err)
-        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
-      }
-    },
-  )
-
-  // --- Tool: insert_icon ---
-  server.tool(
-    'insert_icon',
-    'Insert a Fluent UI icon onto a slide. Fetches SVG from CDN, optionally recolors it, and inserts via Office.js. Use search_icons first to find the icon ID. Pass color as hex to tint mono icons.',
-    {
-      iconId: z
-        .string()
-        .describe('Icon ID from search_icons (e.g. "Icons_Warning_M" for mono, "Icons_Warning" for filled)'),
-      slideIndex: z
-        .number()
-        .int()
-        .min(0)
-        .optional()
-        .describe('Zero-based slide index. If omitted, inserts on the currently active slide.'),
-      x: z.number().optional().describe('Horizontal position in points (1 point = 1/72 inch)'),
-      y: z.number().optional().describe('Vertical position in points'),
-      width: z.number().optional().describe('Icon width in points (default 72)'),
-      height: z.number().optional().describe('Icon height in points (default 72)'),
-      color: z
-        .string()
-        .optional()
-        .describe('Hex color to tint the icon (e.g. "#FF5733"). Works best with mono (_M) icons.'),
-      presentationId: z
-        .string()
-        .optional()
-        .describe('Target presentation ID from list_presentations. Optional when only one presentation is connected.'),
-    },
-    async ({ iconId, slideIndex, x, y, width, height, color, presentationId }) => {
-      try {
-        // Step 1: Fetch and recolor SVG
-        const base64Data = await fetchIconSvg(iconId, color)
-
-        // Step 2: Build options object string with only provided params
-        const optionsParts: string[] = ['coercionType: Office.CoercionType.Image']
-        if (x !== undefined) optionsParts.push(`imageLeft: ${x}`)
-        if (y !== undefined) optionsParts.push(`imageTop: ${y}`)
-        if (width !== undefined) optionsParts.push(`imageWidth: ${width}`)
-        if (height !== undefined) optionsParts.push(`imageHeight: ${height}`)
-        const optionsStr = `{ ${optionsParts.join(', ')} }`
-
-        // Step 3: Build the setSelectedDataAsync call
-        const insertCall = `Office.context.document.setSelectedDataAsync("${base64Data}", ${optionsStr}, function(result) {
-        if (result.status === Office.AsyncResultStatus.Succeeded) {
-          resolve({ success: true });
-        } else {
-          reject(new Error(result.error.message));
-        }
-      });`
-
-        // Step 4: Wrap with goToByIdAsync if slideIndex is provided
-        let code: string
-        if (slideIndex !== undefined) {
-          code = `return new Promise(function(resolve, reject) {
-      Office.context.document.goToByIdAsync(${slideIndex + 1}, Office.GoToType.Index, function(navResult) {
-        if (navResult.status !== Office.AsyncResultStatus.Succeeded) {
-          reject(new Error("Navigation failed: " + navResult.error.message));
-          return;
-        }
-        ${insertCall}
-      });
-    });`
-        } else {
-          code = `return new Promise(function(resolve, reject) {
-      ${insertCall}
-    });`
-        }
-
-        const target = pool.resolveTarget(presentationId)
-        const result = await pool.sendCommand('executeCode', { code }, target.ws)
-        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount())
-        const text = JSON.stringify(result ?? { success: true, iconId }, null, 2) + (warning ?? '')
-        return { content: [{ type: 'text' as const, text }] }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err)
         return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }

--- a/skills/powerpoint-live/SKILL.md
+++ b/skills/powerpoint-live/SKILL.md
@@ -67,7 +67,7 @@ Key return formats to know:
 
 - **`scan_slide`** returns `{ slideWidth, slideHeight, slides: [{ slideIndex, slideId, shapes: [{ id, name, type, left, top, width, height }] }] }` — `id` is a stable numeric string (use this for read/edit tools); `name` is locale-dependent (never use as selector); `type` is one of "GeometricShape", "TextBox", "Table", "Chart", "Picture", "Group"
 - **`verify_slides`** returns `{ slideIndex, issues: [{ type, description, shapeIds }] }` — `type` is "overlap", "bounds", "empty_text", "tiny_shapes", or "unused_placeholder"; `shapeIds` are stable IDs
-- **`search_icons`** returns `[{ id, description, isMono, contentTier, searchScore }]` — `isMono: false` = filled/colorful, `isMono: true` = outline/mono; pick highest `searchScore` matching intent
+- **`search_fluent_icons`** returns `[{ id, description, isMono, contentTier, searchScore, svgUrl }]` — `isMono: false` = filled/colorful, `isMono: true` = outline/mono; pick highest `searchScore` matching intent; use `svgUrl` with `insert_image` (sourceType: "url") to insert
 - **`read_slide_text`** returns raw OOXML `<a:p>` paragraph elements (does NOT include `<a:bodyPr>` or `<a:lstStyle>`)
 - **`read_slide_zip`** returns `{ zipContents: { path: content }, allPaths: [...] }`
 
@@ -80,7 +80,7 @@ Key return formats to know:
 | `format_shapes` | Uses `getTextFrameOrNullObject()` internally. Cannot set corner radius, borders, or gradients — use `edit_slide_xml` code mode for those. Color format: hex without `#`. |
 | `edit_slide_master` | The `zip` contains the full PPTX structure (not a single slide). `p:bg` must be first child of `p:cSld`. |
 | `verify_slides` | Must auto-size shapes first or stale dimensions cause missed overlaps. Table overflow needs API fix, not OOXML. |
-| `insert_icon` | `noChangeAspect` is locked (can't stretch). `color` requires `#` prefix: `"#FF5733"`. Do NOT use `shape.fill.setSolidColor()` for icons. |
+| `insert_image` | `color` param recolors SVG images only (e.g. Fluent UI icons from `search_fluent_icons`). Errors on non-SVG. `#` prefix required: `"#FF5733"`. |
 | `execute_officejs` | Loaded values are snapshots — don't branch on stale reads after writes without re-load + re-sync. |
 
 ### OOXML sz Units (hundredths of a point)
@@ -350,7 +350,7 @@ For charts, use `edit_slide_chart` (declarative) or `edit_slide_zip` (raw OOXML)
 - Prefer more slides with less content over fewer dense slides
 - Use full slide area — stretch content to fill, don't leave large margins
 - Never use emoji or Unicode symbols as icons — use geometric shapes as icon substitutes
-- **Use icons to enhance content slides.** When a slide has key points, categories, or features, add relevant icons alongside the text. Always attempt `search_icons` before falling back to geometric shapes.
+- **Use icons to enhance content slides.** When a slide has key points, categories, or features, add relevant icons alongside the text. Always attempt `search_fluent_icons` before falling back to geometric shapes.
 
 ## Slide Layout Recipes
 

--- a/skills/powerpoint-live/references/code-patterns.md
+++ b/skills/powerpoint-live/references/code-patterns.md
@@ -683,24 +683,24 @@ shape.setZOrder("BringToFront"); // or "BringForward", "SendBackward", "SendToBa
 
 ## Icons
 
-Workflow: `search_icons` → `insert_icon`
+Workflow: `search_fluent_icons` → `insert_image`
 
 ```
-search_icons(query: "warning", top: 5)
-// Returns: [{ id, description, isMono, contentTier, searchScore }]
+search_fluent_icons(query: "warning", top: 5)
+// Returns: [{ id, description, isMono, contentTier, searchScore, svgUrl }]
 
-insert_icon(iconId: "Icons_Warning", slideIndex: 0, x: 100, y: 100, width: 48, height: 48, color: "#FF5733")
+insert_image(source: result.svgUrl, sourceType: "url", slideIndex: 0, left: 100, top: 100, width: 48, height: 48, color: "#FF5733")
 ```
 
 **Variants:** filled (`isMono: false`, e.g. `Icons_Dog`) = colorful. Mono (`isMono: true`, e.g. `Icons_Dog_M`) = clean line-art. Prefer mono (`_M`) variants for professional decks — they're cleaner and recolorable.
 
 **Sizing:** 36-48pt inline next to text, 72pt default, 72-144pt decorative hero.
 
-**Coloring:** Pass `color` hex to `insert_icon`. Do NOT use `shape.fill.setSolidColor()` — that sets shape background, not SVG paths. To recolor existing icons: use `edit_slide_xml` to modify SVG, inject `<style>.iconFill{fill:#HEX;}</style>` after opening `<svg>` tag.
+**Coloring:** Pass `color` hex to `insert_image`. Only works with SVG sources — errors on non-SVG. Do NOT use `shape.fill.setSolidColor()` — that sets shape background, not SVG paths.
 
-**Parallel operations:** When placing icons on multiple cards, search for ALL icons in parallel (multiple `search_icons` calls at once), then insert ALL icons in parallel (multiple `insert_icon` calls at once). This is significantly faster than sequential one-at-a-time operations.
+**Parallel operations:** When placing icons on multiple cards, search for ALL icons in parallel (multiple `search_fluent_icons` calls at once), then insert ALL icons in parallel (multiple `insert_image` calls at once). This is significantly faster than sequential one-at-a-time operations.
 
-**Retry with alternative keywords:** If `search_icons` returns no good matches, retry with synonyms or related concepts:
+**Retry with alternative keywords:** If `search_fluent_icons` returns no good matches, retry with synonyms or related concepts:
 - Abstract concepts → concrete objects: "innovation" → "lightbulb", "opinionated" → "compass", "security" → "shield"
 - Actions → objects: "assessment" → "clipboard", "collaboration" → "handshake", "engineering" → "wrench"
 - Compound concepts → simpler: "no lock-in" → "unlock", "faster delivery" → "rocket"


### PR DESCRIPTION
## Summary
- Adds `search_icons` tool — fuzzy search across Fluent UI icon index with keyword matching
- Adds `insert_icon` tool — insert matched icons as SVG shapes into slides
- Includes icon index builder script (`scripts/build-icon-index.ts`)
- 26 new tests for icon search/matching logic

Closes #41

## Test plan
- [ ] `npm run check` passes (lint + typecheck + 197 tests)
- [ ] Live test: `search_icons` returns relevant Fluent UI icons
- [ ] Live test: `insert_icon` inserts SVG into a slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)