### PR TITLE
chore: switch dev MCP to HTTP transport for autonomous restart

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,8 @@
 {
   "mcpServers": {
     "powerpoint-bridge": {
-      "command": "node",
-      "args": [
-        "${CLAUDE_PLUGIN_ROOT}/dist/index.cjs",
-        "--stdio",
-        "--bridge"
-      ]
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,13 @@ For tool reference, code patterns, and usage — see the **powerpoint-live** ski
 
 ## Development Workflow
 
+### MCP Dev Server
+- `.mcp.json` uses `"type": "http"` pointing to `http://localhost:3001/mcp` — the server must be running separately
+- **Start**: `nohup node --experimental-strip-types ./server/index.ts --http --bridge > /tmp/powerpoint-bridge.log 2>&1 &`
+- **Restart** (after code changes): `pkill -f "server/index.ts"; nohup node --experimental-strip-types ./server/index.ts --http --bridge > /tmp/powerpoint-bridge.log 2>&1 &`
+- No build step needed for dev — runs directly from TypeScript source
+- Claude can restart the server autonomously via Bash (no user interaction needed)
+
 ### Build
 - **After changing `server/` files**: Run `npm run build` and stage `dist/index.cjs` — it's committed and used by plugin/MCPB installs. The pre-commit hook enforces this.
 - **Quality gate**: Use `npm run check` (runs lint + typecheck + test in one command)


### PR DESCRIPTION
## Summary
- Switch `.mcp.json` from command-based (STDIO) to HTTP transport (`type: http`, `url: localhost:3001/mcp`)
- Server runs separately from source (no build step needed for dev)
- Claude can autonomously restart the MCP server via Bash after code changes
- Document the dev server workflow in CLAUDE.md

## Test plan
- [x] Verified HTTP MCP connects and tools are available
- [x] Tested `inspect_deck` and `inspect_layouts` via HTTP transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)