### PR TITLE
docs: update setup instructions for plugin-era distribution

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# This script is for standalone/development use only.
+# Plugin users: run `claude plugin add kzarzycki/powerpoint-bridge` instead.
 set -e
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"

--- a/skills/powerpoint-live/references/setup.md
+++ b/skills/powerpoint-live/references/setup.md
@@ -2,22 +2,73 @@
 
 ## Plugin install (recommended)
 
-If you installed powerpoint-bridge as a Claude Code plugin, everything is automatic:
+Install as a Claude Code plugin — this is the simplest way to get started:
+
+```bash
+claude plugin add kzarzycki/powerpoint-bridge
+```
+
+This gives you:
 - MCP server starts via stdio when Claude Code launches
 - Bridge server starts in the same process (add-in connection on port 8080)
-- Add-in manifest is auto-sideloaded to PowerPoint on first run
+- Skills auto-discovered by the plugin system
 
-Verify by calling `list_presentations`. If it returns results or "No presentations connected", setup is complete.
+### Sideload the PowerPoint add-in
 
-## Per-project setup (standalone)
+The plugin handles the MCP server, but PowerPoint still needs the add-in manifest sideloaded once:
 
-For standalone users without the plugin, run these steps when asked to enable PowerPoint MCP in a project. Each step is idempotent — check before acting, skip what's already done.
+```bash
+# From the plugin's repo directory:
+node scripts/sideload.mjs
+```
 
-### 1. Check if already configured
+Then restart PowerPoint to load the add-in.
 
-Look for `powerpoint-bridge` in the project's `.mcp.json`. If it exists, skip to step 3 (verify).
+### Verify
 
-### 2. Add MCP config
+Call `list_presentations`. If it returns results or "No presentations connected", setup is complete.
+
+## Standalone setup (for developers)
+
+If you're developing on the bridge itself or prefer not to use the plugin:
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/kzarzycki/powerpoint-bridge.git
+cd powerpoint-bridge
+npm install
+```
+
+### 2. Sideload the add-in
+
+```bash
+npm run sideload
+```
+
+Restart PowerPoint after sideloading.
+
+### 3. Start the bridge server
+
+Start the server once in HTTP mode — it stays running across Claude Code sessions:
+
+```bash
+nohup node --experimental-strip-types ./server/index.ts --http --bridge > /tmp/powerpoint-bridge.log 2>&1 &
+```
+
+To restart after code changes:
+
+```bash
+pkill -f "server/index.ts"
+nohup node --experimental-strip-types ./server/index.ts --http --bridge > /tmp/powerpoint-bridge.log 2>&1 &
+```
+
+HTTP mode is preferred over STDIO for development because:
+- Multiple Claude Code sessions can connect simultaneously
+- Claude can autonomously restart the server via Bash (closes the dev feedback loop)
+- No build step needed — runs directly from TypeScript source
+
+### 4. Add MCP config to your project
 
 Create or merge into the project's `.mcp.json`:
 
@@ -25,15 +76,32 @@ Create or merge into the project's `.mcp.json`:
 {
   "mcpServers": {
     "powerpoint-bridge": {
-      "command": "node",
-      "args": ["<path-to-powerpoint-bridge>/server/index.ts", "--stdio", "--bridge"]
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
     }
   }
 }
 ```
 
-Replace `<path-to-powerpoint-bridge>` with the absolute path to the repo. If `.mcp.json` already exists with other servers, merge — do not overwrite.
+If `.mcp.json` already exists with other servers, merge — do not overwrite.
 
-### 3. Verify connectivity
+<details>
+<summary>Alternative: STDIO mode (single session)</summary>
 
-Call `list_presentations`. If it returns results or "No presentations connected", setup is complete. Report status to user.
+```json
+{
+  "mcpServers": {
+    "powerpoint-bridge": {
+      "command": "node",
+      "args": ["<path-to-powerpoint-bridge>/dist/index.cjs", "--stdio", "--bridge"]
+    }
+  }
+}
+```
+
+STDIO ties the server lifecycle to Claude Code — you can't restart it independently.
+</details>
+
+### 5. Verify
+
+Call `list_presentations`. If it returns results or "No presentations connected", setup is complete.


### PR DESCRIPTION
## Summary
- Lead with `claude plugin add kzarzycki/powerpoint-bridge` as the primary install method in `skills/powerpoint-live/references/setup.md`
- Move manual/standalone setup to a secondary section for developers, update MCP config to use `dist/index.cjs`
- Add clarifying comment to `scripts/setup.sh` that it's for standalone/development use only

## Test plan
- [ ] Verify `npm run check` passes (lint, typecheck, tests)
- [ ] Confirm sideloading instructions still reference `scripts/sideload.mjs` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)