### PR TITLE
fix: use health endpoint for hook idempotency check

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -sf http://localhost:3001/mcp > /dev/null 2>&1 || nohup node ${CLAUDE_PLUGIN_ROOT}/dist/index.cjs --http --bridge > /tmp/powerpoint-mcp.log 2>&1 &"
+            "command": "curl -sf http://localhost:8080/health > /dev/null 2>&1 || nohup node ${CLAUDE_PLUGIN_ROOT}/dist/index.cjs --http --bridge > /tmp/powerpoint-mcp.log 2>&1 &"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- The MCP endpoint returns HTTP 400 for bare requests (no session), so `curl -sf` fails and the SessionStart hook tries to re-launch the server every time
- Switch to the bridge health endpoint on port 8080 which returns 200 OK
- Hook now correctly skips when the server is already running

Found during local testing of the SessionStart hook.

## Test plan
- [x] `curl -sf http://localhost:8080/health` returns 200 when server is running
- [x] Hook skips server start when already running (idempotent)
- [x] Hook starts server when not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)