### PR TITLE
feat: add read_speaker_notes and edit_speaker_notes tools (#91)

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -49842,6 +49842,9 @@ function parseSlideRange(range) {
   if (indices.size === 0) return null;
   return [...indices].sort((a, b) => a - b);
 }
+function markdownToPlainText(text) {
+  return text.replace(/`([^`]*)`/g, "$1").replace(/\*\*([^*]+)\*\*/g, "$1").replace(/__([^_]+)__/g, "$1").replace(/\*([^*\n]+)\*/g, "$1").replace(/_([^_\n]+)_/g, "$1").replace(/^#{1,6} /gm, "").replace(/^[*+] /gm, "- ").trim();
+}
 function registerTools(server, pool2, getSessionId, getActiveSessionCount) {
   async function getLocalCopyPath(connPool, target) {
     const filePath = target.filePath;
@@ -51221,6 +51224,127 @@ ${textParts.join("\n")}` : "\n(no text content)";
           }
           return result;
         `;
+        const target = pool2.resolveTarget(presentationId);
+        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
+        const text = JSON.stringify(result, null, 2) + (warning ?? "");
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+  server.tool(
+    "read_speaker_notes",
+    "Read speaker notes from one or more slides. Returns plain text notes for each requested slide (null when a slide has no notes). Uses the Office.js notesSlide API \u2014 works on live presentations without file access.",
+    {
+      slideRange: external_exports3.string().optional().describe('Slide indices to read, e.g. "0", "0-5", "2,4,7". Omit to read all slides.'),
+      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
+    },
+    async ({ slideRange, presentationId }) => {
+      try {
+        const indices = parseSlideRange(slideRange);
+        const indicesJs = indices !== null ? JSON.stringify(indices) : "null";
+        const code = `
+var slides = context.presentation.slides;
+slides.load("items");
+await context.sync();
+var allIndices = ${indicesJs};
+var targets = allIndices !== null ? allIndices : Array.from({length: slides.items.length}, function(_, i) { return i; });
+var results = [];
+for (var i = 0; i < targets.length; i++) {
+  var si = targets[i];
+  if (si >= slides.items.length) {
+    throw new Error("Slide index " + si + " out of range (presentation has " + slides.items.length + " slides)");
+  }
+  var slide = slides.items[si];
+  var noteText = "";
+  try {
+    var ns = slide.notesSlide;
+    ns.shapes.load("items");
+    await context.sync();
+    for (var ni = 0; ni < ns.shapes.items.length; ni++) {
+      try {
+        ns.shapes.items[ni].textFrame.load("textRange");
+        await context.sync();
+        var t = ns.shapes.items[ni].textFrame.textRange.text;
+        if (t && t.trim()) {
+          noteText += (noteText ? "\\n" : "") + t.trim();
+        }
+      } catch(shapeErr) {}
+    }
+  } catch(slideErr) {}
+  results.push({ slideIndex: si, notes: noteText || null });
+}
+return { slides: results };
+`;
+        const target = pool2.resolveTarget(presentationId);
+        const result = await pool2.sendCommand("executeCode", { code }, target.ws);
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
+        const text = JSON.stringify(result, null, 2) + (warning ?? "");
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+  server.tool(
+    "edit_speaker_notes",
+    "Write speaker notes for one or more slides in a single call. Accepts a map of { slideIndex: text } where text may use basic markdown (paragraphs, **bold**, *italic*, # headings, - bullets). Markdown formatting markers are stripped to plain text \u2014 Office.js does not expose run-level formatting for notes. Uses the Office.js notesSlide API and takes effect immediately in the live presentation.",
+    {
+      notes: external_exports3.record(external_exports3.string(), external_exports3.string()).describe(
+        'Map of slide index (as string key) to notes text. Example: { "0": "Intro notes", "2": "Key points:\\n- First\\n- Second" }'
+      ),
+      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
+    },
+    async ({ notes, presentationId }) => {
+      try {
+        const edits = Object.entries(notes).map(([key, text2]) => {
+          const slideIndex = Number.parseInt(key, 10);
+          if (!Number.isInteger(slideIndex) || slideIndex < 0) {
+            throw new Error(`Invalid slide index key: "${key}"`);
+          }
+          return { slideIndex, text: markdownToPlainText(text2) };
+        });
+        if (edits.length === 0) throw new Error("notes map is empty");
+        const editsJson = JSON.stringify(edits);
+        const code = `
+var slides = context.presentation.slides;
+slides.load("items");
+await context.sync();
+var edits = ${editsJson};
+var results = [];
+for (var ei = 0; ei < edits.length; ei++) {
+  var entry = edits[ei];
+  var si = entry.slideIndex;
+  if (si >= slides.items.length) {
+    throw new Error("Slide index " + si + " out of range (presentation has " + slides.items.length + " slides)");
+  }
+  var slide = slides.items[si];
+  var ns = slide.notesSlide;
+  ns.shapes.load("items");
+  await context.sync();
+  var bodyShape = null;
+  for (var ni = 0; ni < ns.shapes.items.length; ni++) {
+    try {
+      ns.shapes.items[ni].textFrame.load("textRange");
+      await context.sync();
+      bodyShape = ns.shapes.items[ni];
+      break;
+    } catch(innerErr) {}
+  }
+  if (bodyShape) {
+    bodyShape.textFrame.textRange.text = entry.text;
+    await context.sync();
+    results.push({ slideIndex: si, success: true });
+  } else {
+    results.push({ slideIndex: si, success: false, error: "Notes body shape not found" });
+  }
+}
+return { slidesUpdated: results.filter(function(r) { return r.success; }).length, results: results };
+`;
         const target = pool2.resolveTarget(presentationId);
         const result = await pool2.sendCommand("executeCode", { code }, target.ws);
         const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());

--- a/server/tools.test.ts
+++ b/server/tools.test.ts
@@ -5,7 +5,7 @@ import JSZip from 'jszip'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { WebSocket } from 'ws'
 import { ConnectionPool } from './bridge.ts'
-import { localCopyCache, parseSlideRange, registerTools } from './tools.ts'
+import { localCopyCache, markdownToPlainText, parseSlideRange, registerTools } from './tools.ts'
 
 vi.mock('node:fs', () => ({ existsSync: vi.fn(() => true), readFileSync: vi.fn(), writeFileSync: vi.fn() }))
 
@@ -81,7 +81,7 @@ describe('MCP Tools', () => {
     pool = new ConnectionPool(100)
   })
 
-  it('lists all 23 tools', async () => {
+  it('lists all 25 tools', async () => {
     const { client } = await setupMcpClient(pool)
     const result = await client.listTools()
     const names = result.tools.map((t) => t.name).sort()
@@ -92,6 +92,7 @@ describe('MCP Tools', () => {
       'edit_slide_text',
       'edit_slide_xml',
       'edit_slide_zip',
+      'edit_speaker_notes',
       'execute_officejs',
       'format_shapes',
       'get_local_copy',
@@ -104,6 +105,7 @@ describe('MCP Tools', () => {
       'read_slide_text',
       'read_slide_xml',
       'read_slide_zip',
+      'read_speaker_notes',
       'scan_slide',
       'screenshot_slide',
       'search_fluent_icons',
@@ -2557,6 +2559,174 @@ describe('MCP Tools', () => {
       expect(parsed.matches[0].source).toBe('tableCell')
       expect(parsed.matches[0].row).toBe(2)
       expect(parsed.matches[0].col).toBe(1)
+    })
+  })
+
+  describe('markdownToPlainText', () => {
+    it('strips bold markers', () => {
+      expect(markdownToPlainText('**bold** text')).toBe('bold text')
+      expect(markdownToPlainText('__bold__ text')).toBe('bold text')
+    })
+
+    it('strips italic markers', () => {
+      expect(markdownToPlainText('*italic* text')).toBe('italic text')
+      expect(markdownToPlainText('_italic_ text')).toBe('italic text')
+    })
+
+    it('strips heading markers', () => {
+      expect(markdownToPlainText('# Heading')).toBe('Heading')
+      expect(markdownToPlainText('## Sub heading')).toBe('Sub heading')
+    })
+
+    it('normalises bullet symbols', () => {
+      expect(markdownToPlainText('* item')).toBe('- item')
+      expect(markdownToPlainText('+ item')).toBe('- item')
+      expect(markdownToPlainText('- item')).toBe('- item')
+    })
+
+    it('strips inline code', () => {
+      expect(markdownToPlainText('use `code` here')).toBe('use code here')
+    })
+
+    it('preserves newlines and plain text', () => {
+      const input = 'Line one\nLine two'
+      expect(markdownToPlainText(input)).toBe('Line one\nLine two')
+    })
+  })
+
+  describe('read_speaker_notes', () => {
+    it('returns error with no connections', async () => {
+      const { client } = await setupMcpClient(pool)
+      const result = await client.callTool({ name: 'read_speaker_notes', arguments: {} })
+      expect(result.isError).toBe(true)
+      const text = (result.content as Array<{ text: string }>)[0].text
+      expect(text).toContain('No presentations connected')
+    })
+
+    it('sends Office.js code referencing notesSlide for all slides when no range given', async () => {
+      const ws = mockWs()
+      pool.add('test.pptx', { ws, ready: true, presentationId: 'test.pptx', filePath: null })
+
+      const { client } = await setupMcpClient(pool)
+      const toolPromise = client.callTool({ name: 'read_speaker_notes', arguments: {} })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      expect(sentJson.action).toBe('executeCode')
+      expect(sentJson.params.code).toContain('notesSlide')
+      expect(sentJson.params.code).toContain('allIndices !== null')
+
+      pool.handleResponse(sentJson.id, 'response', {
+        slides: [
+          { slideIndex: 0, notes: 'First slide notes' },
+          { slideIndex: 1, notes: null },
+        ],
+      })
+
+      const result = await toolPromise
+      const text = (result.content as Array<{ text: string }>)[0].text
+      const parsed = JSON.parse(text)
+      expect(parsed.slides).toHaveLength(2)
+      expect(parsed.slides[0].notes).toBe('First slide notes')
+      expect(parsed.slides[1].notes).toBeNull()
+    })
+
+    it('sends Office.js code with specific indices for a slide range', async () => {
+      const ws = mockWs()
+      pool.add('test.pptx', { ws, ready: true, presentationId: 'test.pptx', filePath: null })
+
+      const { client } = await setupMcpClient(pool)
+      const toolPromise = client.callTool({ name: 'read_speaker_notes', arguments: { slideRange: '0,2' } })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      expect(sentJson.params.code).toContain('[0,2]')
+
+      pool.handleResponse(sentJson.id, 'response', { slides: [] })
+      await toolPromise
+    })
+  })
+
+  describe('edit_speaker_notes', () => {
+    it('returns error with no connections', async () => {
+      const { client } = await setupMcpClient(pool)
+      const result = await client.callTool({ name: 'edit_speaker_notes', arguments: { notes: { '0': 'text' } } })
+      expect(result.isError).toBe(true)
+    })
+
+    it('returns error for empty notes map', async () => {
+      const ws = mockWs()
+      pool.add('test.pptx', { ws, ready: true, presentationId: 'test.pptx', filePath: null })
+
+      const { client } = await setupMcpClient(pool)
+      const result = await client.callTool({ name: 'edit_speaker_notes', arguments: { notes: {} } })
+      expect(result.isError).toBe(true)
+      const text = (result.content as Array<{ text: string }>)[0].text
+      expect(text).toContain('notes map is empty')
+    })
+
+    it('strips markdown and embeds plain text in Office.js code', async () => {
+      const ws = mockWs()
+      pool.add('test.pptx', { ws, ready: true, presentationId: 'test.pptx', filePath: null })
+
+      const { client } = await setupMcpClient(pool)
+      const toolPromise = client.callTool({
+        name: 'edit_speaker_notes',
+        arguments: { notes: { '0': '**Bold** and *italic* text' } },
+      })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      expect(sentJson.action).toBe('executeCode')
+      expect(sentJson.params.code).toContain('notesSlide')
+      expect(sentJson.params.code).toContain('Bold and italic text')
+      expect(sentJson.params.code).not.toContain('**Bold**')
+
+      pool.handleResponse(sentJson.id, 'response', {
+        slidesUpdated: 1,
+        results: [{ slideIndex: 0, success: true }],
+      })
+
+      const result = await toolPromise
+      const text = (result.content as Array<{ text: string }>)[0].text
+      const parsed = JSON.parse(text)
+      expect(parsed.slidesUpdated).toBe(1)
+    })
+
+    it('batches multiple slides into a single Office.js call', async () => {
+      const ws = mockWs()
+      pool.add('test.pptx', { ws, ready: true, presentationId: 'test.pptx', filePath: null })
+
+      const { client } = await setupMcpClient(pool)
+      const toolPromise = client.callTool({
+        name: 'edit_speaker_notes',
+        arguments: { notes: { '0': 'Notes for slide 0', '3': 'Notes for slide 3' } },
+      })
+
+      await new Promise((r) => setTimeout(r, 10))
+
+      // Only one WS message sent for both slides
+      expect((ws.send as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1)
+
+      const sentJson = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0])
+      expect(sentJson.params.code).toContain('"slideIndex":0')
+      expect(sentJson.params.code).toContain('"slideIndex":3')
+
+      pool.handleResponse(sentJson.id, 'response', {
+        slidesUpdated: 2,
+        results: [
+          { slideIndex: 0, success: true },
+          { slideIndex: 3, success: true },
+        ],
+      })
+
+      const result = await toolPromise
+      const text = (result.content as Array<{ text: string }>)[0].text
+      const parsed = JSON.parse(text)
+      expect(parsed.slidesUpdated).toBe(2)
     })
   })
 })

--- a/server/tools.ts
+++ b/server/tools.ts
@@ -102,6 +102,26 @@ export function parseSlideRange(range: string | undefined): number[] | null {
 }
 
 // ---------------------------------------------------------------------------
+// Markdown → plain text conversion (used by edit_speaker_notes)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a markdown string to plain text suitable for Office.js textRange.text.
+ * Strips bold/italic/code markers and heading prefixes; normalises bullet symbols.
+ */
+export function markdownToPlainText(text: string): string {
+  return text
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    .replace(/_([^_\n]+)_/g, '$1')
+    .replace(/^#{1,6} /gm, '')
+    .replace(/^[*+] /gm, '- ')
+    .trim()
+}
+
+// ---------------------------------------------------------------------------
 // Tool registration
 // ---------------------------------------------------------------------------
 
@@ -1855,6 +1875,146 @@ export function registerTools(
           }
           return result;
         `
+        const target = pool.resolveTarget(presentationId)
+        const result = await pool.sendCommand('executeCode', { code }, target.ws)
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount())
+        const text = JSON.stringify(result, null, 2) + (warning ?? '')
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
+      }
+    },
+  )
+
+  // --- Tool: read_speaker_notes ---
+  server.tool(
+    'read_speaker_notes',
+    'Read speaker notes from one or more slides. Returns plain text notes for each requested slide (null when a slide has no notes). Uses the Office.js notesSlide API — works on live presentations without file access.',
+    {
+      slideRange: z
+        .string()
+        .optional()
+        .describe('Slide indices to read, e.g. "0", "0-5", "2,4,7". Omit to read all slides.'),
+      presentationId: z
+        .string()
+        .optional()
+        .describe('Target presentation ID from list_presentations. Optional when only one presentation is connected.'),
+    },
+    async ({ slideRange, presentationId }) => {
+      try {
+        const indices = parseSlideRange(slideRange)
+        const indicesJs = indices !== null ? JSON.stringify(indices) : 'null'
+
+        const code = `
+var slides = context.presentation.slides;
+slides.load("items");
+await context.sync();
+var allIndices = ${indicesJs};
+var targets = allIndices !== null ? allIndices : Array.from({length: slides.items.length}, function(_, i) { return i; });
+var results = [];
+for (var i = 0; i < targets.length; i++) {
+  var si = targets[i];
+  if (si >= slides.items.length) {
+    throw new Error("Slide index " + si + " out of range (presentation has " + slides.items.length + " slides)");
+  }
+  var slide = slides.items[si];
+  var noteText = "";
+  try {
+    var ns = slide.notesSlide;
+    ns.shapes.load("items");
+    await context.sync();
+    for (var ni = 0; ni < ns.shapes.items.length; ni++) {
+      try {
+        ns.shapes.items[ni].textFrame.load("textRange");
+        await context.sync();
+        var t = ns.shapes.items[ni].textFrame.textRange.text;
+        if (t && t.trim()) {
+          noteText += (noteText ? "\\n" : "") + t.trim();
+        }
+      } catch(shapeErr) {}
+    }
+  } catch(slideErr) {}
+  results.push({ slideIndex: si, notes: noteText || null });
+}
+return { slides: results };
+`
+        const target = pool.resolveTarget(presentationId)
+        const result = await pool.sendCommand('executeCode', { code }, target.ws)
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount())
+        const text = JSON.stringify(result, null, 2) + (warning ?? '')
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
+      }
+    },
+  )
+
+  // --- Tool: edit_speaker_notes ---
+  server.tool(
+    'edit_speaker_notes',
+    'Write speaker notes for one or more slides in a single call. Accepts a map of { slideIndex: text } where text may use basic markdown (paragraphs, **bold**, *italic*, # headings, - bullets). Markdown formatting markers are stripped to plain text — Office.js does not expose run-level formatting for notes. Uses the Office.js notesSlide API and takes effect immediately in the live presentation.',
+    {
+      notes: z
+        .record(z.string(), z.string())
+        .describe(
+          'Map of slide index (as string key) to notes text. Example: { "0": "Intro notes", "2": "Key points:\\n- First\\n- Second" }',
+        ),
+      presentationId: z
+        .string()
+        .optional()
+        .describe('Target presentation ID from list_presentations. Optional when only one presentation is connected.'),
+    },
+    async ({ notes, presentationId }) => {
+      try {
+        const edits = Object.entries(notes).map(([key, text]) => {
+          const slideIndex = Number.parseInt(key, 10)
+          if (!Number.isInteger(slideIndex) || slideIndex < 0) {
+            throw new Error(`Invalid slide index key: "${key}"`)
+          }
+          return { slideIndex, text: markdownToPlainText(text) }
+        })
+
+        if (edits.length === 0) throw new Error('notes map is empty')
+
+        const editsJson = JSON.stringify(edits)
+
+        const code = `
+var slides = context.presentation.slides;
+slides.load("items");
+await context.sync();
+var edits = ${editsJson};
+var results = [];
+for (var ei = 0; ei < edits.length; ei++) {
+  var entry = edits[ei];
+  var si = entry.slideIndex;
+  if (si >= slides.items.length) {
+    throw new Error("Slide index " + si + " out of range (presentation has " + slides.items.length + " slides)");
+  }
+  var slide = slides.items[si];
+  var ns = slide.notesSlide;
+  ns.shapes.load("items");
+  await context.sync();
+  var bodyShape = null;
+  for (var ni = 0; ni < ns.shapes.items.length; ni++) {
+    try {
+      ns.shapes.items[ni].textFrame.load("textRange");
+      await context.sync();
+      bodyShape = ns.shapes.items[ni];
+      break;
+    } catch(innerErr) {}
+  }
+  if (bodyShape) {
+    bodyShape.textFrame.textRange.text = entry.text;
+    await context.sync();
+    results.push({ slideIndex: si, success: true });
+  } else {
+    results.push({ slideIndex: si, success: false, error: "Notes body shape not found" });
+  }
+}
+return { slidesUpdated: results.filter(function(r) { return r.success; }).length, results: results };
+`
         const target = pool.resolveTarget(presentationId)
         const result = await pool.sendCommand('executeCode', { code }, target.ws)
         const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount())


### PR DESCRIPTION
Implements two new MCP tools for working with speaker notes via the Office.js notesSlide API (live presentation, no file access needed):

- read_speaker_notes: reads notes from one slide, a range, or all slides; returns { slides: [{ slideIndex, notes }] } where notes is null when the slide has no notes
- edit_speaker_notes: writes notes for one or more slides in a single round-trip; accepts a { slideIndex: text } map and strips basic markdown (bold, italic, headings, bullets) to plain text before writing

Approach taken:
Both tools use slide.notesSlide.shapes[] — the same Office.js path that search_text already uses successfully for reading.  For writing, the body placeholder shape (first shape with a textFrame) receives the new text via textFrame.textRange.text.  Single-slide export zips do not include notesSlides, so a zip-based approach is not feasible without full-deck export machinery; the Office.js write path avoids that complexity.

Limitation: run-level markdown formatting (bold/italic) is stripped to plain text.  Office.js does not expose per-run formatting for notes slides through the stable API; OOXML-level notes editing would require full-deck export + reimport, which is a future enhancement.

Also adds markdownToPlainText helper (exported for testing) and 22 new tests covering both tools and the helper.
