### PR TITLE
feat: add read_deck_text and rename read/edit_slide_text tools

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -49799,6 +49799,130 @@ async function extractLayoutsFromZip(zip) {
   }
   return layouts;
 }
+async function extractDeckText(zipBuffer, slideIndices, includeNotes) {
+  const zip = await import_jszip.default.loadAsync(zipBuffer);
+  const slideFiles = Object.keys(zip.files).filter((p) => /^ppt\/slides\/slide\d+\.xml$/.test(p)).sort((a, b) => {
+    const na = parseInt(a.match(/slide(\d+)/)[1], 10);
+    const nb = parseInt(b.match(/slide(\d+)/)[1], 10);
+    return na - nb;
+  });
+  const results = [];
+  const parser = new import_xmldom.DOMParser();
+  const allowed = slideIndices ? new Set(slideIndices) : null;
+  for (let i = 0; i < slideFiles.length; i++) {
+    if (allowed && !allowed.has(i)) continue;
+    const slideFile = slideFiles[i];
+    const slideNum = parseInt(slideFile.match(/slide(\d+)/)[1], 10);
+    const xmlStr = await zip.file(slideFile).async("string");
+    const doc = parser.parseFromString(xmlStr, "text/xml");
+    let title = "";
+    const body = [];
+    const shapes = doc.getElementsByTagNameNS(NS_P, "sp");
+    for (let j = 0; j < shapes.length; j++) {
+      const shape = shapes[j];
+      let isTitle = false;
+      const nvSpPr = shape.getElementsByTagNameNS(NS_P, "nvSpPr");
+      if (nvSpPr.length > 0) {
+        const phElements = nvSpPr[0].getElementsByTagNameNS(NS_P, "ph");
+        if (phElements.length > 0) {
+          const phType = phElements[0].getAttribute("type");
+          isTitle = phType === "title" || phType === "ctrTitle";
+        }
+      }
+      const txBody = shape.getElementsByTagNameNS(NS_P, "txBody");
+      if (txBody.length === 0) continue;
+      const paragraphs = txBody[0].getElementsByTagNameNS(NS_A, "p");
+      const lines = [];
+      for (let p = 0; p < paragraphs.length; p++) {
+        const runs = paragraphs[p].getElementsByTagNameNS(NS_A, "t");
+        const parts = [];
+        for (let r = 0; r < runs.length; r++) {
+          const t = runs[r].textContent;
+          if (t) parts.push(t);
+        }
+        if (parts.length > 0) lines.push(parts.join(""));
+      }
+      const text = lines.join("\n").trim();
+      if (!text) continue;
+      if (isTitle && !title) {
+        title = text;
+      } else {
+        body.push(text);
+      }
+    }
+    const tables = doc.getElementsByTagNameNS(NS_A, "tbl");
+    for (let t = 0; t < tables.length; t++) {
+      const rows = tables[t].getElementsByTagNameNS(NS_A, "tr");
+      const tableLines = [];
+      for (let r = 0; r < rows.length; r++) {
+        const cells = rows[r].getElementsByTagNameNS(NS_A, "tc");
+        const cellTexts = [];
+        for (let c = 0; c < cells.length; c++) {
+          const runs = cells[c].getElementsByTagNameNS(NS_A, "t");
+          const parts = [];
+          for (let x = 0; x < runs.length; x++) {
+            const txt = runs[x].textContent;
+            if (txt) parts.push(txt);
+          }
+          cellTexts.push(parts.join(""));
+        }
+        tableLines.push(cellTexts.join(" | "));
+      }
+      if (tableLines.length > 0) body.push(tableLines.join("\n"));
+    }
+    const entry = { slide: i, title, body };
+    if (includeNotes) {
+      const relsPath = `ppt/slides/_rels/slide${slideNum}.xml.rels`;
+      const relsFile = zip.file(relsPath);
+      if (relsFile) {
+        const relsXml = await relsFile.async("string");
+        const relsDoc = parser.parseFromString(relsXml, "text/xml");
+        const rels = relsDoc.getElementsByTagName("Relationship");
+        for (let r = 0; r < rels.length; r++) {
+          const relType = rels[r].getAttribute("Type") || "";
+          if (relType.endsWith("/notesSlide")) {
+            const target = rels[r].getAttribute("Target") || "";
+            const notesPath = `ppt/notesSlides/${target.split("/").pop()}`;
+            const notesFile = zip.file(notesPath);
+            if (notesFile) {
+              const notesXml = await notesFile.async("string");
+              const notesDoc = parser.parseFromString(notesXml, "text/xml");
+              const noteShapes = notesDoc.getElementsByTagNameNS(NS_P, "sp");
+              const noteTexts = [];
+              for (let ns = 0; ns < noteShapes.length; ns++) {
+                const nvSpPr2 = noteShapes[ns].getElementsByTagNameNS(NS_P, "nvSpPr");
+                if (nvSpPr2.length > 0) {
+                  const ph2 = nvSpPr2[0].getElementsByTagNameNS(NS_P, "ph");
+                  if (ph2.length > 0) {
+                    const phType2 = ph2[0].getAttribute("type");
+                    if (phType2 === "sldImg" || phType2 === "sldNum" || phType2 === "dt" || phType2 === "hdr" || phType2 === "ftr") continue;
+                  }
+                }
+                const txBody2 = noteShapes[ns].getElementsByTagNameNS(NS_P, "txBody");
+                if (txBody2.length === 0) continue;
+                const paragraphs2 = txBody2[0].getElementsByTagNameNS(NS_A, "p");
+                for (let p2 = 0; p2 < paragraphs2.length; p2++) {
+                  const runs2 = paragraphs2[p2].getElementsByTagNameNS(NS_A, "t");
+                  const parts2 = [];
+                  for (let r2 = 0; r2 < runs2.length; r2++) {
+                    const txt = runs2[r2].textContent;
+                    if (txt) parts2.push(txt);
+                  }
+                  if (parts2.length > 0) noteTexts.push(parts2.join(""));
+                }
+              }
+              const notes = noteTexts.join("\n").trim();
+              if (notes) entry.notes = notes;
+            }
+            break;
+          }
+        }
+      }
+    }
+    results.push(entry);
+  }
+  return results;
+}
 
 // server/tools.ts
 var localCopyCache = /* @__PURE__ */ new Map();
@@ -50520,7 +50644,7 @@ ${textParts.join("\n")}` : "\n(no text content)";
     }
   );
   server.tool(
-    "read_slide_text",
+    "read_shape_paragraphs",
     "Read raw OOXML <a:p> paragraphs from a shape's text body. Returns the paragraph XML as a string \u2014 preserves all formatting (bold, colors, bullets, etc.) that textRange.text strips. Use with the /pptx skill's OOXML knowledge to understand and modify the XML.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index from list_slides results"),
@@ -50546,8 +50670,32 @@ ${textParts.join("\n")}` : "\n(no text content)";
     }
   );
   server.tool(
-    "edit_slide_text",
-    "Replace paragraph content of a shape with raw OOXML <a:p> XML. Preserves <a:bodyPr> and <a:lstStyle>. Use read_slide_text first to get the current XML, modify it (using /pptx skill knowledge), then write it back. The slide is exported, modified server-side, and reimported \u2014 data never enters Claude's context.",
+    "read_deck_text",
+    "Lightweight text extractor: returns slide titles and body text as plain strings (~20x smaller than inspect_slide). Use for content review, narrative analysis, or any read-only text task. Supports slideRange and optional speaker notes.",
+    {
+      slideRange: external_exports3.string().optional().describe('Slide range, e.g. "0-5", "2,4,7". Zero-based. Omit for all slides.'),
+      includeNotes: external_exports3.boolean().optional().describe("Include speaker notes. Default: false."),
+      presentationId: external_exports3.string().optional().describe("Target presentation ID from list_presentations. Optional when only one presentation is connected.")
+    },
+    async ({ slideRange, includeNotes, presentationId }) => {
+      try {
+        const target = pool2.resolveTarget(presentationId);
+        const localPath = await getLocalCopyPath(pool2, target);
+        const zipBuffer = (0, import_node_fs2.readFileSync)(localPath);
+        const indices = slideRange ? parseSlideRange(slideRange) : null;
+        const result = await extractDeckText(zipBuffer, indices, includeNotes === true);
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount());
+        const text = JSON.stringify(result) + (warning ?? "");
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+      }
+    }
+  );
+  server.tool(
+    "edit_shape_paragraphs",
+    "Replace paragraph content of a shape with raw OOXML <a:p> XML. Preserves <a:bodyPr> and <a:lstStyle>. Use read_shape_paragraphs first to get the current XML, modify it (using /pptx skill knowledge), then write it back. The slide is exported, modified server-side, and reimported \u2014 data never enters Claude's context.",
     {
       slideIndex: external_exports3.number().int().min(0).describe("Zero-based slide index"),
       shapeId: external_exports3.string().describe("Shape ID from inspect_slide results"),

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -49998,7 +49998,7 @@ async function extractDeckText(zipBuffer, slideIndices, includeNotes) {
     return na - nb;
   });
   const results = [];
-  const parser = new import_xmldom.DOMParser();
+  const parser = new import_xmldom2.DOMParser();
   const allowed = slideIndices ? new Set(slideIndices) : null;
   for (let i = 0; i < slideFiles.length; i++) {
     if (allowed && !allowed.has(i)) continue;
@@ -50008,24 +50008,24 @@ async function extractDeckText(zipBuffer, slideIndices, includeNotes) {
     const doc = parser.parseFromString(xmlStr, "text/xml");
     let title = "";
     const body = [];
-    const shapes = doc.getElementsByTagNameNS(NS_P, "sp");
+    const shapes = doc.getElementsByTagNameNS(NS_P2, "sp");
     for (let j = 0; j < shapes.length; j++) {
       const shape = shapes[j];
       let isTitle = false;
-      const nvSpPr = shape.getElementsByTagNameNS(NS_P, "nvSpPr");
+      const nvSpPr = shape.getElementsByTagNameNS(NS_P2, "nvSpPr");
       if (nvSpPr.length > 0) {
-        const phElements = nvSpPr[0].getElementsByTagNameNS(NS_P, "ph");
+        const phElements = nvSpPr[0].getElementsByTagNameNS(NS_P2, "ph");
         if (phElements.length > 0) {
           const phType = phElements[0].getAttribute("type");
           isTitle = phType === "title" || phType === "ctrTitle";
         }
       }
-      const txBody = shape.getElementsByTagNameNS(NS_P, "txBody");
+      const txBody = shape.getElementsByTagNameNS(NS_P2, "txBody");
       if (txBody.length === 0) continue;
-      const paragraphs = txBody[0].getElementsByTagNameNS(NS_A, "p");
+      const paragraphs = txBody[0].getElementsByTagNameNS(NS_A2, "p");
       const lines = [];
       for (let p = 0; p < paragraphs.length; p++) {
-        const runs = paragraphs[p].getElementsByTagNameNS(NS_A, "t");
+        const runs = paragraphs[p].getElementsByTagNameNS(NS_A2, "t");
         const parts = [];
         for (let r = 0; r < runs.length; r++) {
           const t = runs[r].textContent;
@@ -50041,15 +50041,15 @@ async function extractDeckText(zipBuffer, slideIndices, includeNotes) {
         body.push(text);
       }
     }
-    const tables = doc.getElementsByTagNameNS(NS_A, "tbl");
+    const tables = doc.getElementsByTagNameNS(NS_A2, "tbl");
     for (let t = 0; t < tables.length; t++) {
-      const rows = tables[t].getElementsByTagNameNS(NS_A, "tr");
+      const rows = tables[t].getElementsByTagNameNS(NS_A2, "tr");
       const tableLines = [];
       for (let r = 0; r < rows.length; r++) {
-        const cells = rows[r].getElementsByTagNameNS(NS_A, "tc");
+        const cells = rows[r].getElementsByTagNameNS(NS_A2, "tc");
         const cellTexts = [];
         for (let c = 0; c < cells.length; c++) {
-          const runs = cells[c].getElementsByTagNameNS(NS_A, "t");
+          const runs = cells[c].getElementsByTagNameNS(NS_A2, "t");
           const parts = [];
           for (let x = 0; x < runs.length; x++) {
             const txt = runs[x].textContent;
@@ -50078,22 +50078,23 @@ async function extractDeckText(zipBuffer, slideIndices, includeNotes) {
             if (notesFile) {
               const notesXml = await notesFile.async("string");
               const notesDoc = parser.parseFromString(notesXml, "text/xml");
-              const noteShapes = notesDoc.getElementsByTagNameNS(NS_P, "sp");
+              const noteShapes = notesDoc.getElementsByTagNameNS(NS_P2, "sp");
               const noteTexts = [];
               for (let ns = 0; ns < noteShapes.length; ns++) {
-                const nvSpPr2 = noteShapes[ns].getElementsByTagNameNS(NS_P, "nvSpPr");
+                const nvSpPr2 = noteShapes[ns].getElementsByTagNameNS(NS_P2, "nvSpPr");
                 if (nvSpPr2.length > 0) {
-                  const ph2 = nvSpPr2[0].getElementsByTagNameNS(NS_P, "ph");
+                  const ph2 = nvSpPr2[0].getElementsByTagNameNS(NS_P2, "ph");
                   if (ph2.length > 0) {
                     const phType2 = ph2[0].getAttribute("type");
-                    if (phType2 === "sldImg" || phType2 === "sldNum" || phType2 === "dt" || phType2 === "hdr" || phType2 === "ftr") continue;
+                    if (phType2 === "sldImg" || phType2 === "sldNum" || phType2 === "dt" || phType2 === "hdr" || phType2 === "ftr")
+                      continue;
                   }
                 }
-                const txBody2 = noteShapes[ns].getElementsByTagNameNS(NS_P, "txBody");
+                const txBody2 = noteShapes[ns].getElementsByTagNameNS(NS_P2, "txBody");
                 if (txBody2.length === 0) continue;
-                const paragraphs2 = txBody2[0].getElementsByTagNameNS(NS_A, "p");
+                const paragraphs2 = txBody2[0].getElementsByTagNameNS(NS_A2, "p");
                 for (let p2 = 0; p2 < paragraphs2.length; p2++) {
-                  const runs2 = paragraphs2[p2].getElementsByTagNameNS(NS_A, "t");
+                  const runs2 = paragraphs2[p2].getElementsByTagNameNS(NS_A2, "t");
                   const parts2 = [];
                   for (let r2 = 0; r2 < runs2.length; r2++) {
                     const txt = runs2[r2].textContent;

--- a/manifest.json
+++ b/manifest.json
@@ -79,11 +79,15 @@
       "description": "Run programmatic checks on a slide (overlap, bounds, empty text, tiny shapes)"
     },
     {
-      "name": "read_slide_text",
+      "name": "read_deck_text",
+      "description": "Lightweight text extractor: slide titles and body as plain strings (~20x smaller than inspect_slide)"
+    },
+    {
+      "name": "read_shape_paragraphs",
       "description": "Read raw OOXML paragraphs from a shape's text body"
     },
     {
-      "name": "edit_slide_text",
+      "name": "edit_shape_paragraphs",
       "description": "Replace paragraph content of a shape with raw OOXML"
     },
     {

--- a/server/tools.test.ts
+++ b/server/tools.test.ts
@@ -88,8 +88,8 @@ describe('MCP Tools', () => {
     expect(names).toEqual([
       'copy_slides',
       'duplicate_slide',
+      'edit_shape_paragraphs',
       'edit_slide_chart',
-      'edit_slide_text',
       'edit_slide_xml',
       'edit_slide_zip',
       'execute_officejs',
@@ -101,7 +101,8 @@ describe('MCP Tools', () => {
       'inspect_slide',
       'list_presentations',
       'preview_deck',
-      'read_slide_text',
+      'read_deck_text',
+      'read_shape_paragraphs',
       'read_slide_xml',
       'read_slide_zip',
       'scan_slide',
@@ -987,7 +988,7 @@ describe('MCP Tools', () => {
     })
   })
 
-  describe('read_slide_text', () => {
+  describe('read_shape_paragraphs', () => {
     it('returns paragraph XML for a shape', async () => {
       const ws = mockWs()
       pool.add('test.pptx', { ws, ready: true, presentationId: 'test.pptx', filePath: null })
@@ -995,7 +996,7 @@ describe('MCP Tools', () => {
       const base64 = await makeSlideZipBase64()
 
       const toolPromise = client.callTool({
-        name: 'read_slide_text',
+        name: 'read_shape_paragraphs',
         arguments: { slideIndex: 0, shapeId: '2' },
       })
 
@@ -1020,7 +1021,7 @@ describe('MCP Tools', () => {
       const base64 = await makeSlideZipBase64()
 
       const toolPromise = client.callTool({
-        name: 'read_slide_text',
+        name: 'read_shape_paragraphs',
         arguments: { slideIndex: 0, shapeId: '999' },
       })
 
@@ -1037,14 +1038,14 @@ describe('MCP Tools', () => {
     it('returns error when no connections', async () => {
       const { client } = await setupMcpClient(pool)
       const result = await client.callTool({
-        name: 'read_slide_text',
+        name: 'read_shape_paragraphs',
         arguments: { slideIndex: 0, shapeId: '2' },
       })
       expect(result.isError).toBe(true)
     })
   })
 
-  describe('edit_slide_text', () => {
+  describe('edit_shape_paragraphs', () => {
     it('exports, modifies paragraphs, and reimports', async () => {
       const ws = mockWs()
       pool.add('test.pptx', { ws, ready: true, presentationId: 'test.pptx', filePath: null })
@@ -1055,7 +1056,7 @@ describe('MCP Tools', () => {
         '<a:p xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:r><a:t>Replaced</a:t></a:r></a:p>'
 
       const toolPromise = client.callTool({
-        name: 'edit_slide_text',
+        name: 'edit_shape_paragraphs',
         arguments: { slideIndex: 0, shapeId: '2', xml: newParagraphXml },
       })
 
@@ -1093,7 +1094,7 @@ describe('MCP Tools', () => {
       const base64 = await makeSlideZipBase64()
 
       const toolPromise = client.callTool({
-        name: 'edit_slide_text',
+        name: 'edit_shape_paragraphs',
         arguments: { slideIndex: 0, shapeId: '999', xml: '<a:p/>' },
       })
 

--- a/server/tools.ts
+++ b/server/tools.ts
@@ -13,6 +13,7 @@ import {
   autoRegisterContentTypes,
   escapeXml,
   exportSlide,
+  extractDeckText,
   extractLayoutsFromZip,
   extractParagraphs,
   extractSlideXmlFromZip,
@@ -974,9 +975,9 @@ export function registerTools(
     },
   )
 
-  // --- Tool: read_slide_text ---
+  // --- Tool: read_shape_paragraphs ---
   server.tool(
-    'read_slide_text',
+    'read_shape_paragraphs',
     "Read raw OOXML <a:p> paragraphs from a shape's text body. Returns the paragraph XML as a string — preserves all formatting (bold, colors, bullets, etc.) that textRange.text strips. Use with the /pptx skill's OOXML knowledge to understand and modify the XML.",
     {
       slideIndex: z.number().int().min(0).describe('Zero-based slide index from list_slides results'),
@@ -1005,10 +1006,39 @@ export function registerTools(
     },
   )
 
-  // --- Tool: edit_slide_text ---
+  // --- Tool: read_deck_text ---
   server.tool(
-    'edit_slide_text',
-    "Replace paragraph content of a shape with raw OOXML <a:p> XML. Preserves <a:bodyPr> and <a:lstStyle>. Use read_slide_text first to get the current XML, modify it (using /pptx skill knowledge), then write it back. The slide is exported, modified server-side, and reimported — data never enters Claude's context.",
+    'read_deck_text',
+    'Lightweight text extractor: returns slide titles and body text as plain strings (~20x smaller than inspect_slide). Use for content review, narrative analysis, or any read-only text task. Supports slideRange and optional speaker notes.',
+    {
+      slideRange: z.string().optional().describe('Slide range, e.g. "0-5", "2,4,7". Zero-based. Omit for all slides.'),
+      includeNotes: z.boolean().optional().describe('Include speaker notes. Default: false.'),
+      presentationId: z
+        .string()
+        .optional()
+        .describe('Target presentation ID from list_presentations. Optional when only one presentation is connected.'),
+    },
+    async ({ slideRange, includeNotes, presentationId }) => {
+      try {
+        const target = pool.resolveTarget(presentationId)
+        const localPath = await getLocalCopyPath(pool, target)
+        const zipBuffer = readFileSync(localPath)
+        const indices = slideRange ? parseSlideRange(slideRange) : null
+        const result = await extractDeckText(zipBuffer, indices, includeNotes === true)
+        const warning = getConcurrentWarning(getSessionId(), target.presentationId, getActiveSessionCount())
+        const text = JSON.stringify(result) + (warning ?? '')
+        return { content: [{ type: 'text' as const, text }] }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true }
+      }
+    },
+  )
+
+  // --- Tool: edit_shape_paragraphs ---
+  server.tool(
+    'edit_shape_paragraphs',
+    "Replace paragraph content of a shape with raw OOXML <a:p> XML. Preserves <a:bodyPr> and <a:lstStyle>. Use read_shape_paragraphs first to get the current XML, modify it (using /pptx skill knowledge), then write it back. The slide is exported, modified server-side, and reimported — data never enters Claude's context.",
     {
       slideIndex: z.number().int().min(0).describe('Zero-based slide index'),
       shapeId: z.string().describe('Shape ID from inspect_slide results'),

--- a/server/xml-helpers.ts
+++ b/server/xml-helpers.ts
@@ -276,7 +276,7 @@ export async function autoRegisterContentTypes(zip: JSZip, newPaths: string[]): 
   zip.file('[Content_Types].xml', ctXml)
 }
 
-// Legacy wrappers — used by existing read/edit_slide_text and read/edit_slide_xml tools
+// Legacy wrappers — used by existing read/edit_shape_paragraphs and read/edit_slide_xml tools
 export async function extractSlideXmlFromZip(base64: string): Promise<{ zip: JSZip; xmlString: string }> {
   const { zip, files } = await extractZipFiles(base64, [SLIDE_XML_PATH])
   return { zip, xmlString: files[SLIDE_XML_PATH]! }
@@ -466,4 +466,180 @@ export async function extractLayoutsFromZip(zip: JSZip): Promise<LayoutInfo[]> {
   }
 
   return layouts
+}
+
+// ---------------------------------------------------------------------------
+// Bulk text extraction from PPTX zip
+// ---------------------------------------------------------------------------
+
+export interface SlideText {
+  slide: number
+  title: string
+  body: string[]
+  notes?: string
+}
+
+/**
+ * Extract plain text from all slides in a PPTX buffer.
+ * Returns structured text with title/body classification and optional speaker notes.
+ */
+export async function extractDeckText(
+  zipBuffer: Buffer,
+  slideIndices?: number[] | null,
+  includeNotes?: boolean,
+): Promise<SlideText[]> {
+  const zip = await JSZip.loadAsync(zipBuffer)
+
+  // Find all slide XML files and sort by slide number
+  const slideFiles = Object.keys(zip.files)
+    .filter((p) => /^ppt\/slides\/slide\d+\.xml$/.test(p))
+    .sort((a, b) => {
+      const na = parseInt(a.match(/slide(\d+)/)![1]!, 10)
+      const nb = parseInt(b.match(/slide(\d+)/)![1]!, 10)
+      return na - nb
+    })
+
+  const results: SlideText[] = []
+  const parser = new DOMParser()
+  const allowed = slideIndices ? new Set(slideIndices) : null
+
+  for (let i = 0; i < slideFiles.length; i++) {
+    if (allowed && !allowed.has(i)) continue
+
+    const slideFile = slideFiles[i]!
+    const slideNum = parseInt(slideFile.match(/slide(\d+)/)![1]!, 10)
+    const xmlStr = await zip.file(slideFile)!.async('string')
+    const doc = parser.parseFromString(xmlStr, 'text/xml')
+
+    let title = ''
+    const body: string[] = []
+
+    // Extract text from all shapes
+    const shapes = doc.getElementsByTagNameNS(NS_P, 'sp')
+    for (let j = 0; j < shapes.length; j++) {
+      const shape = shapes[j]!
+
+      // Check if this is a title placeholder
+      let isTitle = false
+      const nvSpPr = shape.getElementsByTagNameNS(NS_P, 'nvSpPr')
+      if (nvSpPr.length > 0) {
+        const phElements = nvSpPr[0]!.getElementsByTagNameNS(NS_P, 'ph')
+        if (phElements.length > 0) {
+          const phType = phElements[0]!.getAttribute('type')
+          isTitle = phType === 'title' || phType === 'ctrTitle'
+        }
+      }
+
+      // Extract text runs grouped by paragraph
+      const txBody = shape.getElementsByTagNameNS(NS_P, 'txBody')
+      if (txBody.length === 0) continue
+      const paragraphs = txBody[0]!.getElementsByTagNameNS(NS_A, 'p')
+      const lines: string[] = []
+      for (let p = 0; p < paragraphs.length; p++) {
+        const runs = paragraphs[p]!.getElementsByTagNameNS(NS_A, 't')
+        const parts: string[] = []
+        for (let r = 0; r < runs.length; r++) {
+          const t = runs[r]!.textContent
+          if (t) parts.push(t)
+        }
+        if (parts.length > 0) lines.push(parts.join(''))
+      }
+
+      const text = lines.join('\n').trim()
+      if (!text) continue
+
+      if (isTitle && !title) {
+        title = text
+      } else {
+        body.push(text)
+      }
+    }
+
+    // Extract table text
+    const tables = doc.getElementsByTagNameNS(NS_A, 'tbl')
+    for (let t = 0; t < tables.length; t++) {
+      const rows = tables[t]!.getElementsByTagNameNS(NS_A, 'tr')
+      const tableLines: string[] = []
+      for (let r = 0; r < rows.length; r++) {
+        const cells = rows[r]!.getElementsByTagNameNS(NS_A, 'tc')
+        const cellTexts: string[] = []
+        for (let c = 0; c < cells.length; c++) {
+          const runs = cells[c]!.getElementsByTagNameNS(NS_A, 't')
+          const parts: string[] = []
+          for (let x = 0; x < runs.length; x++) {
+            const txt = runs[x]!.textContent
+            if (txt) parts.push(txt)
+          }
+          cellTexts.push(parts.join(''))
+        }
+        tableLines.push(cellTexts.join(' | '))
+      }
+      if (tableLines.length > 0) body.push(tableLines.join('\n'))
+    }
+
+    const entry: SlideText = { slide: i, title, body }
+
+    // Speaker notes
+    if (includeNotes) {
+      const relsPath = `ppt/slides/_rels/slide${slideNum}.xml.rels`
+      const relsFile = zip.file(relsPath)
+      if (relsFile) {
+        const relsXml = await relsFile.async('string')
+        const relsDoc = parser.parseFromString(relsXml, 'text/xml')
+        const rels = relsDoc.getElementsByTagName('Relationship')
+        for (let r = 0; r < rels.length; r++) {
+          const relType = rels[r]!.getAttribute('Type') || ''
+          if (relType.endsWith('/notesSlide')) {
+            const target = rels[r]!.getAttribute('Target') || ''
+            // Target is relative like "../notesSlides/notesSlide1.xml"
+            const notesPath = `ppt/notesSlides/${target.split('/').pop()}`
+            const notesFile = zip.file(notesPath)
+            if (notesFile) {
+              const notesXml = await notesFile.async('string')
+              const notesDoc = parser.parseFromString(notesXml, 'text/xml')
+              const noteShapes = notesDoc.getElementsByTagNameNS(NS_P, 'sp')
+              const noteTexts: string[] = []
+              for (let ns = 0; ns < noteShapes.length; ns++) {
+                // Skip the slide image placeholder in notes
+                const nvSpPr2 = noteShapes[ns]!.getElementsByTagNameNS(NS_P, 'nvSpPr')
+                if (nvSpPr2.length > 0) {
+                  const ph2 = nvSpPr2[0]!.getElementsByTagNameNS(NS_P, 'ph')
+                  if (ph2.length > 0) {
+                    const phType2 = ph2[0]!.getAttribute('type')
+                    if (
+                      phType2 === 'sldImg' ||
+                      phType2 === 'sldNum' ||
+                      phType2 === 'dt' ||
+                      phType2 === 'hdr' ||
+                      phType2 === 'ftr'
+                    )
+                      continue
+                  }
+                }
+                const txBody2 = noteShapes[ns]!.getElementsByTagNameNS(NS_P, 'txBody')
+                if (txBody2.length === 0) continue
+                const paragraphs2 = txBody2[0]!.getElementsByTagNameNS(NS_A, 'p')
+                for (let p2 = 0; p2 < paragraphs2.length; p2++) {
+                  const runs2 = paragraphs2[p2]!.getElementsByTagNameNS(NS_A, 't')
+                  const parts2: string[] = []
+                  for (let r2 = 0; r2 < runs2.length; r2++) {
+                    const txt = runs2[r2]!.textContent
+                    if (txt) parts2.push(txt)
+                  }
+                  if (parts2.length > 0) noteTexts.push(parts2.join(''))
+                }
+              }
+              const notes = noteTexts.join('\n').trim()
+              if (notes) entry.notes = notes
+            }
+            break
+          }
+        }
+      }
+    }
+
+    results.push(entry)
+  }
+
+  return results
 }

--- a/skills/powerpoint-mcp/SKILL.md
+++ b/skills/powerpoint-mcp/SKILL.md
@@ -30,8 +30,9 @@ When asked to enable or configure PowerPoint MCP in a project — follow the [se
 | `copy_slides` | Copy slides between two open presentations (data stays server-side) | `sourceSlideIndex`, `sourcePresentationId`, `destinationPresentationId`, `formatting?`, `targetSlideId?` |
 | `insert_image` | Insert image from file path, URL, or base64 data (data stays server-side for file/url) | `source`, `sourceType` (`file`/`url`/`base64`), `slideIndex?`, `left?`, `top?`, `width?`, `height?`, `presentationId?` |
 | `get_local_copy` | Get a local .pptx file path (passthrough for local files, exports cloud files to temp) | `presentationId?` |
-| `read_slide_text` | Read raw OOXML `<a:p>` paragraphs from a shape (preserves formatting) | `slideIndex`, `shapeId`, `presentationId?` |
-| `edit_slide_text` | Replace paragraph content with raw OOXML (preserves bodyPr/lstStyle) | `slideIndex`, `shapeId`, `xml`, `presentationId?` |
+| `read_deck_text` | Lightweight text extractor: titles + body as plain strings (~20x smaller than inspect_slide) | `slideRange?`, `includeNotes?`, `presentationId?` |
+| `read_shape_paragraphs` | Read raw OOXML `<a:p>` paragraphs from a shape (preserves formatting) | `slideIndex`, `shapeId`, `presentationId?` |
+| `edit_shape_paragraphs` | Replace paragraph content with raw OOXML (preserves bodyPr/lstStyle) | `slideIndex`, `shapeId`, `xml`, `presentationId?` |
 | `read_slide_xml` | Read full slide OOXML or a specific shape's XML | `slideIndex`, `shapeId?`, `presentationId?` |
 | `edit_slide_xml` | Replace full slide XML or a specific shape's XML | `slideIndex`, `xml`, `shapeId?`, `presentationId?` |
 | `read_slide_zip` | Read multiple files from exported slide zip (slide XML, rels, charts) | `slideIndex`, `paths?`, `presentationId?` |
@@ -69,14 +70,14 @@ Key return formats to know:
 - **`scan_slide`** returns `{ slideWidth, slideHeight, slides: [{ slideIndex, slideId, shapes: [{ id, name, type, left, top, width, height }] }] }` — `id` is a stable numeric string (use this for read/edit tools); `name` is locale-dependent (never use as selector); `type` is one of "GeometricShape", "TextBox", "Table", "Chart", "Picture", "Group"
 - **`verify_slides`** returns `{ slideIndex, issues: [{ type, description, shapeIds }] }` — `type` is "overlap", "bounds", "empty_text", "tiny_shapes", or "unused_placeholder"; `shapeIds` are stable IDs
 - **`search_fluent_icons`** returns `[{ id, description, isMono, contentTier, searchScore, svgUrl }]` — `isMono: false` = filled/colorful, `isMono: true` = outline/mono; pick highest `searchScore` matching intent; use `svgUrl` with `insert_image` (sourceType: "url") to insert
-- **`read_slide_text`** returns raw OOXML `<a:p>` paragraph elements (does NOT include `<a:bodyPr>` or `<a:lstStyle>`)
+- **`read_shape_paragraphs`** returns raw OOXML `<a:p>` paragraph elements (does NOT include `<a:bodyPr>` or `<a:lstStyle>`)
 - **`read_slide_zip`** returns `{ zipContents: { path: content }, allPaths: [...] }`
 
 ### Tool Behavior Notes
 
 | Tool | Key non-obvious behavior |
 |------|--------------------------|
-| `edit_slide_text` | The `xml` field takes raw OOXML paragraph XML, not executable code. Preserves `<a:bodyPr>` and `<a:lstStyle>` automatically. Must auto-size shapes after edit. |
+| `edit_shape_paragraphs` | The `xml` field takes raw OOXML paragraph XML, not executable code. Preserves `<a:bodyPr>` and `<a:lstStyle>` automatically. Must auto-size shapes after edit. |
 | `edit_slide_xml` | Two modes: `xml` (finished XML string) or `code` (JS that manipulates pre-parsed DOM server-side). Code mode preserves untouched attributes. Exported slide is ALWAYS `ppt/slides/slide1.xml` in the zip regardless of `slideIndex`. |
 | `format_shapes` | Uses `getTextFrameOrNullObject()` internally. Cannot set corner radius, borders, or gradients — use `edit_slide_xml` code mode for those. Color format: hex without `#`. |
 | `verify_slides` | Must auto-size shapes first or stale dimensions cause missed overlaps. Table overflow needs API fix, not OOXML. |
@@ -227,7 +228,7 @@ Choose the right tool for each edit. Prefer higher tools in this table — fall 
 | Change type | Tool | Why |
 |---|---|---|
 | Fill color, font bold/italic/size/color/name | `format_shapes` | Declarative, 1 call per slide, no XML risk |
-| Mixed formatting within one shape (some words bold, some not) | `edit_slide_text` | Office.js has no paragraph-level font API |
+| Mixed formatting within one shape (some words bold, some not) | `edit_shape_paragraphs` | Office.js has no paragraph-level font API |
 | Geometry (corners, borders), gradients, attributes Office.js cannot set | `edit_slide_xml` with `code` | DOM manipulation preserves untouched attributes |
 | Complex layouts, new shapes, diagrams | `edit_slide_xml` with `code` | Full OOXML control |
 | Simple text writes, shape creation, positioning | `execute_officejs` | Direct Office.js API |
@@ -330,7 +331,7 @@ edit_slide_xml(slideIndex: 2, code: `
 
 ### Legacy: XML string mode
 
-For single-shape paragraph edits, `read_slide_text` / `edit_slide_text` preserves `<a:bodyPr>` and `<a:lstStyle>` automatically. For full slide XML replacement, use `edit_slide_xml` with `xml` — but prefer code mode to avoid accidentally dropping attributes.
+For single-shape paragraph edits, `read_shape_paragraphs` / `edit_shape_paragraphs` preserves `<a:bodyPr>` and `<a:lstStyle>` automatically. For full slide XML replacement, use `edit_slide_xml` with `xml` — but prefer code mode to avoid accidentally dropping attributes.
 
 ## Hard Limitations
 
@@ -395,7 +396,7 @@ Standard cards with a small colored RoundedRectangle "badge" overlaid (e.g., sho
 - No `<!-- -->` comments in code strings — sandbox rejects with `SES_HTML_COMMENT_REJECTED`
 
 **Office.js:**
-- **Never use Office.js to read text content** — `textRange.text` returns plain text with all formatting stripped. Use `read_slide_text` for formatted content. Office.js is for shape metadata (IDs, positions, dimensions) and simple writes.
+- **Never use Office.js to read text content** — `textRange.text` returns plain text with all formatting stripped. Use `read_shape_paragraphs` for formatted content. Office.js is for shape metadata (IDs, positions, dimensions) and simple writes.
 - Use `getTextFrameOrNullObject()` — never `.textFrame` directly (tables/images/charts throw)
 - Loaded values are snapshots — don't branch on stale reads after writes (`hasText` stays stale after setting `textRange.text`)
 - No `paragraphs` collection in PowerPoint Office.js

--- a/skills/powerpoint-mcp/references/code-patterns.md
+++ b/skills/powerpoint-mcp/references/code-patterns.md
@@ -484,12 +484,12 @@ Use the OOXML tools for fine-grained formatting control. Load the `/pptx` skill 
 
 ```
 // 1. Read current paragraphs (raw OOXML)
-read_slide_text(slideIndex: 0, shapeId: "2")
+read_shape_paragraphs(slideIndex: 0, shapeId: "2")
 // Returns: <a:p><a:r><a:rPr lang="en-US" b="1"/><a:t>Hello</a:t></a:r></a:p>
 
 // 2. Modify the XML (add color, change text, etc.)
 // 3. Write back
-edit_slide_text(slideIndex: 0, shapeId: "2", xml: '<a:p><a:r><a:rPr lang="en-US" b="1"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:rPr><a:t>Red Bold</a:t></a:r></a:p>')
+edit_shape_paragraphs(slideIndex: 0, shapeId: "2", xml: '<a:p><a:r><a:rPr lang="en-US" b="1"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:rPr><a:t>Red Bold</a:t></a:r></a:p>')
 ```
 
 For full slide or shape XML editing:

--- a/skills/powerpoint-mcp/references/ooxml-reference.md
+++ b/skills/powerpoint-mcp/references/ooxml-reference.md
@@ -10,7 +10,7 @@
 | Office.js (`execute_officejs`) | Shape creation, positioning, simple text writes — anything the Office.js API exposes directly |
 | OOXML tools (`edit_slide_xml` with `code`) | Geometry (corners, borders), gradients, mixed formatting, precise paragraph control |
 | OOXML tools (`edit_slide_xml` with `xml`) | Full slide XML replacement (rare — prefer code mode to avoid attribute loss) |
-| `edit_slide_text` | Single-shape paragraph editing with OOXML (preserves bodyPr/lstStyle) |
+| `edit_shape_paragraphs` | Single-shape paragraph editing with OOXML (preserves bodyPr/lstStyle) |
 | File-based (`get_local_copy` + `/pptx` skill) | Charts, master/theme editing, rels, Content_Types — anything beyond slide XML |
 
 ## Workflow
@@ -26,9 +26,9 @@ Code mode receives a pre-parsed DOM with helpers. See SKILL.md "OOXML Editing Wo
 ### Legacy: XML string mode (2+ calls)
 
 1. `inspect_slide(slideRange: "N")` → find shape IDs
-2. `read_slide_text(slideIndex, shapeId)` or `read_slide_xml(slideIndex, shapeId?)`
+2. `read_shape_paragraphs(slideIndex, shapeId)` or `read_slide_xml(slideIndex, shapeId?)`
 3. Modify the XML using `/pptx` skill knowledge
-4. `edit_slide_text(slideIndex, shapeId, xml)` or `edit_slide_xml(slideIndex, xml, shapeId?)`
+4. `edit_shape_paragraphs(slideIndex, shapeId, xml)` or `edit_slide_xml(slideIndex, xml, shapeId?)`
 5. `screenshot_slide(slideIndex)` → visual verification
 
 Always inspect before modifying. Always verify after.
@@ -40,21 +40,21 @@ Always inspect before modifying. Always verify after.
 - Always use `inspect_slide` first to discover IDs — don't guess
 - Shape IDs may change after reimport (Office.js assigns new IDs on `insertSlidesFromBase64`)
 
-## read_slide_text / edit_slide_text
+## read_shape_paragraphs / edit_shape_paragraphs
 
 Paragraph-level editing for a single shape:
 
-- `read_slide_text` returns the `<a:p>` paragraph elements from a shape
-- `edit_slide_text` replaces paragraph content — `<a:bodyPr>` and `<a:lstStyle>` are preserved automatically
+- `read_shape_paragraphs` returns the `<a:p>` paragraph elements from a shape
+- `edit_shape_paragraphs` replaces paragraph content — `<a:bodyPr>` and `<a:lstStyle>` are preserved automatically
 - You only work with the paragraph XML (the `<a:p>` elements)
 
 ```
 // Read current paragraphs
-read_slide_text(slideIndex: 0, shapeId: "2")
+read_shape_paragraphs(slideIndex: 0, shapeId: "2")
 // Returns: <a:p><a:r><a:rPr lang="en-US" b="1"/><a:t>Hello</a:t></a:r></a:p>
 
 // Write modified paragraphs back
-edit_slide_text(slideIndex: 0, shapeId: "2", xml: '<a:p>..modified..</a:p>')
+edit_shape_paragraphs(slideIndex: 0, shapeId: "2", xml: '<a:p>..modified..</a:p>')
 ```
 
 ## read_slide_xml / edit_slide_xml
@@ -80,14 +80,14 @@ Use full-slide mode for batch editing multiple shapes in a single reimport.
 
 Each edit tool call triggers a full export → modify → delete → reimport cycle:
 
-- Multiple `edit_slide_text` calls on the same slide = multiple reimports (visible flashing)
+- Multiple `edit_shape_paragraphs` calls on the same slide = multiple reimports (visible flashing)
 - **For 2+ shapes on the same slide**: use `read_slide_xml` (full slide, no shapeId) → modify all shapes in the XML → `edit_slide_xml` (full slide) — single reimport, no flashing
 
 ```
 // Bad: 3 reimports, visible flashing
-edit_slide_text(slideIndex: 0, shapeId: "2", xml: '...')
-edit_slide_text(slideIndex: 0, shapeId: "5", xml: '...')
-edit_slide_text(slideIndex: 0, shapeId: "7", xml: '...')
+edit_shape_paragraphs(slideIndex: 0, shapeId: "2", xml: '...')
+edit_shape_paragraphs(slideIndex: 0, shapeId: "5", xml: '...')
+edit_shape_paragraphs(slideIndex: 0, shapeId: "7", xml: '...')
 
 // Good: 1 reimport, no flashing
 xml = read_slide_xml(slideIndex: 0)          // full slide
@@ -384,7 +384,7 @@ When full pptx export is added, theme editing involves:
 
 ### The Core Rule
 
-**Never use Office.js to read text content.** `textRange.text` returns plain text — all formatting (bold, font size, color, bullets) is stripped. Use `read_slide_text` to read. Office.js is only for shape metadata (IDs, positions, dimensions) and simple plain-text writes.
+**Never use Office.js to read text content.** `textRange.text` returns plain text — all formatting (bold, font size, color, bullets) is stripped. Use `read_shape_paragraphs` to read. Office.js is only for shape metadata (IDs, positions, dimensions) and simple plain-text writes.
 
 ### OOXML Text Elements Reference
 
@@ -466,7 +466,7 @@ Some templates use explicit `marL`/`indent` attributes instead of `lvl` for bull
 
 ### DOs
 
-- Always call `read_slide_text` before `edit_slide_text` to see the existing XML
+- Always call `read_shape_paragraphs` before `edit_shape_paragraphs` to see the existing XML
 - Copy every `<a:p>` block verbatim from the read output, then make only the specific change needed
 - Copy formatting from similar paragraphs when adding new content — new bullets should use the same `<a:pPr>` and `<a:rPr>` as existing ones
 - Use `<a:buChar>` in `<a:pPr>` for native PowerPoint bullets
@@ -482,9 +482,9 @@ Some templates use explicit `marL`/`indent` attributes instead of `lvl` for bull
 - Don't put the `•` character in `<a:t>` — use `<a:buChar char="•"/>` in `<a:pPr>`
 - Don't mix header and bullet formatting — headers use `<a:buNone/>` with different attributes
 
-### edit_slide_text Preserves bodyPr and lstStyle
+### edit_shape_paragraphs Preserves bodyPr and lstStyle
 
-`edit_slide_text` automatically preserves the shape's `<a:bodyPr>` and `<a:lstStyle>` — you only provide the `<a:p>` paragraph elements. This means text anchoring, margins, and list style definitions carry over automatically. The `replaceTextBody` helper below mirrors this behavior for batch edits via `edit_slide_xml`.
+`edit_shape_paragraphs` automatically preserves the shape's `<a:bodyPr>` and `<a:lstStyle>` — you only provide the `<a:p>` paragraph elements. This means text anchoring, margins, and list style definitions carry over automatically. The `replaceTextBody` helper below mirrors this behavior for batch edits via `edit_slide_xml`.
 
 ### Batch Edit Helpers
 
@@ -507,7 +507,7 @@ function findShapeById(doc, id) {
 function replaceTextBody(doc, shape, paragraphXml) {
   var txBody = shape.getElementsByTagNameNS(NS_P, "txBody")[0];
   if (!txBody) return;
-  // Preserve bodyPr and lstStyle (same as edit_slide_text behavior)
+  // Preserve bodyPr and lstStyle (same as edit_shape_paragraphs behavior)
   var bodyPr = txBody.getElementsByTagNameNS(NS_A, "bodyPr")[0];
   var lstStyle = txBody.getElementsByTagNameNS(NS_A, "lstStyle")[0];
   while (txBody.firstChild) txBody.removeChild(txBody.firstChild);


### PR DESCRIPTION
## Summary

- **New `read_deck_text` tool** — lightweight text extractor that returns slide titles + body text as plain strings (~20x smaller than `inspect_slide`). Pure TypeScript using existing JSZip + xmldom, zero new dependencies. Supports `slideRange` filtering and optional speaker notes.
- **Renamed `read_slide_text` → `read_shape_paragraphs`** and `edit_slide_text` → `edit_shape_paragraphs` — names now honestly reflect they return raw OOXML `<a:p>` paragraph XML, not plain text.
- Updated all references across docs (SKILL.md, ooxml-reference.md, code-patterns.md), manifest.json, and tests.

## Test plan

- [x] All 207 tests pass (7 test files)
- [x] Build succeeds (CJS + ESM)
- [ ] Live test: call `read_deck_text` on an open presentation → verify structured JSON output
- [ ] Live test: call with `slideRange: "0-2"` → verify filtering
- [ ] Live test: call with `includeNotes: true` → verify speaker notes included
- [ ] Live test: call `read_shape_paragraphs` → verify backwards-compatible OOXML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)