### PR TITLE
docs: surface Office.js sandbox API pitfalls in code-patterns

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
   "files": {
-    "includes": ["server/**/*.ts", "addin/**/*.js", "e2e/**/*.ts"]
+    "includes": ["server/**/*.ts", "addin/**/*.js", "e2e/**/*.ts", "!.claude/**"]
   },
   "formatter": {
     "indentStyle": "space",

--- a/skills/powerpoint-mcp/references/code-patterns.md
+++ b/skills/powerpoint-mcp/references/code-patterns.md
@@ -145,6 +145,16 @@ var placeholders = shapes.items.filter(function(s) { return s.type === "Placehol
 // placeholders tell you where the chrome is — build content below them
 ```
 
+## API Pitfalls (sandbox runtime)
+
+The bridge runs Office.js inside a sandboxed WKWebView. A few APIs that look correct per official docs are unreliable here — use the right column.
+
+| Don't | Do | Why |
+|-------|----|----|
+| `shapes.addGeometricShape(PowerPoint.GeometricShapeType.rectangle)` | `shapes.addGeometricShape("Rectangle")` | The `Office.PowerPoint.ShapeType` / `PowerPoint.GeometricShapeType` enum is often `undefined` in the sandbox — pass the string literal instead. |
+| `shape.fill.setForeColor("FFFF00")` | `shape.fill.setSolidColor("FFFF00")` | `setForeColor` is not on the fill object in this runtime. |
+| `slides[0]` | `slides.getItemAt(0)` or `slides.items[0]` after `load("items")` + `sync()` | Bracket indexing does not work on Office.js collections. |
+
 ## Geometric Shapes
 
 ```javascript
@@ -153,14 +163,14 @@ slides.load("items");
 await context.sync();
 var shapes = slides.items[0].shapes;
 
-// Add rectangle
-var rect = shapes.addGeometricShape(PowerPoint.GeometricShapeType.rectangle);
+// Add rectangle (use the string form — the enum is unreliable in the sandbox)
+var rect = shapes.addGeometricShape("Rectangle");
 rect.left = 100; rect.top = 100; rect.width = 200; rect.height = 150;
 rect.fill.setSolidColor("#2196F3");
 await context.sync();
 ```
 
-Use string literals for shape types:
+Shape types must be passed as string literals:
 
 ```javascript
 var shape = shapes.addGeometricShape("Rectangle", {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    exclude: ['node_modules/**', 'e2e/**'],
+    exclude: ['node_modules/**', 'e2e/**', '.claude/**'],
   },
 })


### PR DESCRIPTION
## Summary
- Adds a 3-row "API Pitfalls" callout near the top of the Geometric Shapes section in `skills/powerpoint-mcp/references/code-patterns.md`. Documents three APIs that return `undefined` in the bridge's WKWebView sandbox even though the official Office.js docs list them as supported:
  - `PowerPoint.GeometricShapeType` / `Office.PowerPoint.ShapeType` enums → use the string literal
  - `shape.fill.setForeColor` → use `setSolidColor`
  - `slides[0]` (bracket indexing) → `getItemAt(0)` or `.items[0]` after `load`+`sync`
- Fixes the Geometric Shapes example, which contradicted the rule by calling `addGeometricShape` with the enum.
- Tooling: excludes `.claude/**` from vitest and biome scans so worktrees under `.claude/worktrees/` don't get pulled into the test run / config discovery (duplicate-test errors, "nested root configuration" error).

Source: empirical notes from a prior session that produced a standalone `skills/officejs/` mini-skill. Folded the substance into the existing skill rather than carrying a duplicate.

## Test plan
- [x] `npm run check` passes (242 tests).
- [ ] Read the rendered table in `skills/powerpoint-mcp/references/code-patterns.md` — formatting OK.
- [ ] Spot-check: no other examples in that file still use `PowerPoint.GeometricShapeType.*` for shapes. (One `addLine(PowerPoint.ConnectorType.straight, ...)` example remains — out of scope here, separate question whether to update.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)